### PR TITLE
Updated examples for NEST 3

### DIFF
--- a/pynest/examples/CampbellSiegert.py
+++ b/pynest/examples/CampbellSiegert.py
@@ -209,5 +209,4 @@ print('mean membrane potential (actual / calculated): {0} / {1}'
 print('variance (actual / calculated): {0} / {1}'
       .format(np.var(v_free[Nskip:]), sigma2 * 1e6))
 print('firing rate (actual / calculated): {0} / {1}'
-      .format(nest.GetStatus(sd, 'n_events')[0] /
-              (n_neurons * simtime * ms), r))
+      .format(sd.n_events / (n_neurons * simtime * ms), r))

--- a/pynest/examples/balancedneuron.py
+++ b/pynest/examples/balancedneuron.py
@@ -84,7 +84,7 @@ voltmeter = nest.Create("voltmeter")
 spikedetector = nest.Create("spike_detector")
 
 ###################################################################################
-# Fourth, the ``poisson_generator`` (`noise`) is configured using ``set``.
+# Fourth, the ``poisson_generator`` (`noise`) is configured.
 # Note that we need not set parameters for the neuron, the spike detector, and
 # the voltmeter, since they have satisfactory defaults.
 

--- a/pynest/examples/brunel_alpha_evolution_strategies.py
+++ b/pynest/examples/brunel_alpha_evolution_strategies.py
@@ -232,12 +232,11 @@ def simulate(parameters):
     nest.SetKernelStatus({'rng_seeds': [parameters['seed']],
                           'resolution': parameters['dt']})
 
-    nest.SetDefaults('iaf_psc_alpha', neuron_parameters)
-    nest.SetDefaults('poisson_generator', {'rate': p_rate})
-
     nodes_ex = nest.Create('iaf_psc_alpha', NE)
     nodes_in = nest.Create('iaf_psc_alpha', NI)
-    noise = nest.Create('poisson_generator')
+    nodes_ex.set(neuron_parameters)
+    nodes_in.set(neuron_parameters)
+    noise = nest.Create('poisson_generator', params={'rate': p_rate})
     espikes = nest.Create('spike_detector', params={'label': 'brunel-py-ex'})
     ispikes = nest.Create('spike_detector', params={'label': 'brunel-py-in'})
 

--- a/pynest/examples/brunel_alpha_nest.py
+++ b/pynest/examples/brunel_alpha_nest.py
@@ -25,9 +25,6 @@
 This script simulates an excitatory and an inhibitory population on
 the basis of the network used in [1]_.
 
-In contrast to ``brunel-alpha-numpy.py``, this variant uses NEST's builtin
-connection routines to draw the random connections instead of NumPy.
-
 When connecting the network customary synapse models are used, which
 allow for querying the number of created synapses. Using spike
 detectors the average firing rates of the neurons in the populations
@@ -172,24 +169,15 @@ nest.SetKernelStatus({"resolution": dt, "print_time": True,
 print("Building network")
 
 ###############################################################################
-# Configuration of the model ``iaf_psc_alpha`` and ``poisson_generator`` using
-# ``SetDefaults``. This function expects the model to be the inserted as a
-# string and the parameter to be specified in a dictionary. All instances of
-# theses models created after this point will have the properties specified
-# in the dictionary by default.
-
-nest.SetDefaults("iaf_psc_alpha", neuron_params)
-nest.SetDefaults("poisson_generator", {"rate": p_rate})
-
-###############################################################################
 # Creation of the nodes using ``Create``. We store the returned handles in
 # variables for later reference. Here the excitatory and inhibitory, as well
 # as the poisson generator and two spike detectors. The spike detectors will
-# later be used to record excitatory and inhibitory spikes.
+# later be used to record excitatory and inhibitory spikes. Properties of the
+# nodes are inserted via ``param``, which expects a dictinary.
 
-nodes_ex = nest.Create("iaf_psc_alpha", NE)
-nodes_in = nest.Create("iaf_psc_alpha", NI)
-noise = nest.Create("poisson_generator")
+nodes_ex = nest.Create("iaf_psc_alpha", NE, param=neuron_params)
+nodes_in = nest.Create("iaf_psc_alpha", NI, param=neuron_params)
+noise = nest.Create("poisson_generator", param={"rate": p_rate})
 espikes = nest.Create("spike_detector")
 ispikes = nest.Create("spike_detector")
 

--- a/pynest/examples/brunel_delta_nest.py
+++ b/pynest/examples/brunel_delta_nest.py
@@ -127,24 +127,15 @@ nest.SetKernelStatus({"resolution": dt, "print_time": True,
 print("Building network")
 
 ###############################################################################
-# Configuration of the model ``iaf_psc_delta`` and ``poisson_generator`` using
-# ``SetDefaults``. This function expects the model to be the inserted as a
-# string and the parameter to be specified in a dictionary. All instances of
-# theses models created after this point will have the properties specified
-# in the dictionary by default.
-
-nest.SetDefaults("iaf_psc_delta", neuron_params)
-nest.SetDefaults("poisson_generator", {"rate": p_rate})
-
-###############################################################################
 # Creation of the nodes using ``Create``. We store the returned handles in
 # variables for later reference. Here the excitatory and inhibitory, as well
 # as the poisson generator and two spike detectors. The spike detectors will
-# later be used to record excitatory and inhibitory spikes.
+# later be used to record excitatory and inhibitory spikes. Properties of the
+# nodes are inserted via ``param``, which expects a dictinary.
 
-nodes_ex = nest.Create("iaf_psc_delta", NE)
-nodes_in = nest.Create("iaf_psc_delta", NI)
-noise = nest.Create("poisson_generator")
+nodes_ex = nest.Create("iaf_psc_delta", NE, param=neuron_params)
+nodes_in = nest.Create("iaf_psc_delta", NI, param=neuron_params)
+noise = nest.Create("poisson_generator", param={"rate": p_rate})
 espikes = nest.Create("spike_detector")
 ispikes = nest.Create("spike_detector")
 

--- a/pynest/examples/brunel_exp_multisynapse_nest.py
+++ b/pynest/examples/brunel_exp_multisynapse_nest.py
@@ -142,25 +142,16 @@ nest.SetKernelStatus({"resolution": dt, "print_time": True,
 
 print("Building network")
 
-##################################################################################
-# Configuration of the model ``iaf_psc_exp_multisynapse`` and
-# ``poisson_generator`` using ``SetDefaults``. This function expects the model to
-# be the inserted as a string and the parameter to be specified in a
-# dictionary. All instances of theses models created after this point will
-# have the properties specified in the dictionary by default.
-
-nest.SetDefaults("iaf_psc_exp_multisynapse", neuron_params)
-nest.SetDefaults("poisson_generator", {"rate": p_rate})
-
 ###############################################################################
 # Creation of the nodes using ``Create``. We store the returned handles in
 # variables for later reference. Here the excitatory and inhibitory, as well
 # as the poisson generator and two spike detectors. The spike detectors will
-# later be used to record excitatory and inhibitory spikes.
+# later be used to record excitatory and inhibitory spikes. Properties of the
+# nodes are inserted via ``param``, which expects a dictinary.
 
-nodes_ex = nest.Create("iaf_psc_exp_multisynapse", NE)
-nodes_in = nest.Create("iaf_psc_exp_multisynapse", NI)
-noise = nest.Create("poisson_generator")
+nodes_ex = nest.Create("iaf_psc_exp_multisynapse", NE, param=neuron_params)
+nodes_in = nest.Create("iaf_psc_exp_multisynapse", NI, param=neuron_params)
+noise = nest.Create("poisson_generator", param={"rate": p_rate})
 espikes = nest.Create("spike_detector")
 ispikes = nest.Create("spike_detector")
 

--- a/pynest/examples/brunel_siegert_nest.py
+++ b/pynest/examples/brunel_siegert_nest.py
@@ -124,17 +124,12 @@ nest.SetKernelStatus({"resolution": dt, "print_time": True,
 print("Building network")
 
 ###############################################################################
-# Configuration of the model ``siegert_neuron`` using ``SetDefaults``.
-
-nest.SetDefaults("siegert_neuron", neuron_params)
-
-###############################################################################
 # Creation of the nodes using ``Create``. One rate neuron represents the
 # excitatory population of LIF-neurons in the SLIFN and one the inhibitory
 # population assuming homogeneity of the populations.
 
-siegert_ex = nest.Create("siegert_neuron", 1)
-siegert_in = nest.Create("siegert_neuron", 1)
+siegert_ex = nest.Create("siegert_neuron", params=neuron_params)
+siegert_in = nest.Create("siegert_neuron", params=neuron_params)
 
 ###############################################################################
 # The Poisson drive in the SLIFN is replaced by a driving rate neuron,
@@ -142,7 +137,7 @@ siegert_in = nest.Create("siegert_neuron", 1)
 # neuron is controlled by setting ``mean`` to the rate of the corresponding
 # poisson generator in the SLIFN.
 
-siegert_drive = nest.Create('siegert_neuron', 1, params={'mean': p_rate})
+siegert_drive = nest.Create('siegert_neuron', params={'mean': p_rate})
 
 ###############################################################################
 # To record from the rate neurons a multimeter is created and the parameter

--- a/pynest/examples/clopath_synapse_small_network.py
+++ b/pynest/examples/clopath_synapse_small_network.py
@@ -116,7 +116,7 @@ nest.Connect(pop_input, pop_inh, conn_dict_input_to_inh, syn_dict_input_to_inh)
 
 # Create exc->exc connections
 nest.CopyModel('clopath_synapse', 'clopath_exc_to_exc',
-               {'Wmax': 0.75, 'weight_recorder': wr[0]})
+               {'Wmax': 0.75, 'weight_recorder': wr})
 syn_dict_exc_to_exc = {'synapse_model': 'clopath_exc_to_exc', 'weight': 0.25,
                        'delay': delay}
 conn_dict_exc_to_exc = {'rule': 'all_to_all', 'allow_autapses': False}
@@ -157,7 +157,7 @@ for i in range(int(simulation_time/sim_interval)):
 ##############################################################################
 # Plot results
 
-fig1, axA = plt.subplots(1, sharex=False)
+fig, ax = plt.subplots(1, sharex=False)
 
 # Plot synapse weights of the synapses within the excitatory population
 # Sort weights according to sender and reshape
@@ -186,13 +186,13 @@ weight_matrix[tl10[0], tl10[1]] = weights[tl9[0], tl9[1]]
 init_w_matrix = np.ones((10, 10))*0.25
 init_w_matrix -= np.identity(10)*0.25
 
-caxA = axA.imshow(weight_matrix - init_w_matrix)
-cbarB = fig1.colorbar(caxA, ax=axA)
-axA.set_xticks([0, 2, 4, 6, 8])
-axA.set_xticklabels(['1', '3', '5', '7', '9'])
-axA.set_yticks([0, 2, 4, 6, 8])
-axA.set_xticklabels(['1', '3', '5', '7', '9'])
-axA.set_xlabel("to neuron")
-axA.set_ylabel("from neuron")
-axA.set_title("Change of syn weights before and after simulation")
+cax = ax.imshow(weight_matrix - init_w_matrix)
+cbarB = fig.colorbar(cax, ax=ax)
+ax.set_xticks([0, 2, 4, 6, 8])
+ax.set_xticklabels(['1', '3', '5', '7', '9'])
+ax.set_yticks([0, 2, 4, 6, 8])
+ax.set_xticklabels(['1', '3', '5', '7', '9'])
+ax.set_xlabel("to neuron")
+ax.set_ylabel("from neuron")
+ax.set_title("Change of syn weights before and after simulation")
 plt.show()

--- a/pynest/examples/clopath_synapse_spike_pairing.py
+++ b/pynest/examples/clopath_synapse_spike_pairing.py
@@ -103,7 +103,7 @@ resolution = 0.1
 ##############################################################################
 # Loop over pairs of spike trains
 
-for (s_t_pre, s_t_post) in zip(spike_times_pre, spike_times_post):
+for s_t_pre, s_t_post in zip(spike_times_pre, spike_times_post):
     nest.ResetKernel()
     nest.SetKernelStatus({"resolution": resolution})
 
@@ -115,17 +115,16 @@ for (s_t_pre, s_t_post) in zip(spike_times_pre, spike_times_post):
     prrt_nrn = nest.Create("parrot_neuron", 1)
 
     # Create and connect spike generators
-    spike_gen_pre = nest.Create("spike_generator", 1, {
-                                "spike_times": s_t_pre})
+    spike_gen_pre = nest.Create("spike_generator", 1,
+                                {"spike_times": s_t_pre})
 
     nest.Connect(spike_gen_pre, prrt_nrn,
                  syn_spec={"delay": resolution})
 
-    spike_gen_post = nest.Create("spike_generator", 1, {
-                                 "spike_times": s_t_post})
+    spike_gen_post = nest.Create("spike_generator", 1,
+                                 {"spike_times": s_t_post})
 
-    nest.Connect(spike_gen_post, nrn, syn_spec={
-                 "delay": resolution, "weight": 80.0})
+    nest.Connect(spike_gen_post, nrn, syn_spec={"delay": resolution, "weight": 80.0})
 
     # Create weight recorder
     wr = nest.Create('weight_recorder', 1)
@@ -150,14 +149,14 @@ syn_weights = np.array(syn_weights)
 syn_weights = 100.0*15.0*(syn_weights - init_w)/init_w + 100.0
 
 # Plot results
-fig1, axA = plt.subplots(1, sharex=False)
-axA.plot([10., 20., 30., 40., 50.], syn_weights[5:], color='b', lw=2.5, ls='-',
-         label="pre-post pairing")
-axA.plot([10., 20., 30., 40., 50.], syn_weights[:5], color='g', lw=2.5, ls='-',
-         label="post-pre pairing")
-axA.set_ylabel("normalized weight change")
-axA.set_xlabel("rho (Hz)")
-axA.legend()
-axA.set_title("synaptic weight")
+fig, ax = plt.subplots(1, sharex=False)
+ax.plot([10., 20., 30., 40., 50.], syn_weights[5:], color='b', lw=2.5, ls='-',
+        label="pre-post pairing")
+ax.plot([10., 20., 30., 40., 50.], syn_weights[:5], color='g', lw=2.5, ls='-',
+        label="post-pre pairing")
+ax.set_ylabel("normalized weight change")
+ax.set_xlabel("rho (Hz)")
+ax.legend()
+ax.set_title("synaptic weight")
 
 plt.show()

--- a/pynest/examples/correlospinmatrix_detector_two_neuron.py
+++ b/pynest/examples/correlospinmatrix_detector_two_neuron.py
@@ -47,12 +47,11 @@ tau_max = 100.
 csd = nest.Create("correlospinmatrix_detector")
 csd.set(N_channels=2, tau_max=tau_max, Tstart=tau_max, delta_tau=h)
 
-nest.SetDefaults('ginzburg_neuron', {'theta': 0.0, 'tau_m': tau_m,
-                                     'c_1': 0.0, 'c_2': 2. * m_x, 'c_3': 1.0})
 n1 = nest.Create("ginzburg_neuron")
+n1.set(theta=0.0, tau_m=tau_m, c_1=0.0, c_2=2. * m_x, c_3=1.0)
 
-nest.SetDefaults("mcculloch_pitts_neuron", {'theta': 0.5, 'tau_m': tau_m})
 n2 = nest.Create("mcculloch_pitts_neuron")
+n2.set(theta=0.5, tau_m=tau_m)
 
 nest.Connect(n1, n2, syn_spec={"weight": 1.0})
 
@@ -61,27 +60,27 @@ nest.Connect(n2, csd, syn_spec={"receptor_type": 1})
 
 nest.Simulate(T)
 
-c = csd.get("count_covariance")
+count_covariance = csd.count_covariance
 
-m = np.zeros(2, dtype=float)
+mean_activities = np.zeros(2, dtype=float)
 for i in range(2):
-    m[i] = c[i][i][int(tau_max / h)] * (h / T)
+    mean_activities[i] = count_covariance[i][i][int(tau_max / h)] * (h / T)
 
-print('mean activities =', m)
+print('mean activities =', mean_activities)
 
-cmat = np.zeros((2, 2, int(2 * tau_max / h) + 1), dtype=float)
+covariance_matrix = np.zeros((2, 2, int(2 * tau_max / h) + 1), dtype=float)
 for i in range(2):
     for j in range(2):
-        cmat[i, j] = c[i][j] * (h / T) - m[i] * m[j]
+        covariance_matrix[i, j] = count_covariance[i][j] * (h / T) - mean_activities[i] * mean_activities[j]
 
 ts = np.arange(-tau_max, tau_max + h, h)
 
 plt.title("auto- and cross covariance functions")
 
-plt.plot(ts, cmat[0, 1], 'r', label=r"$c_{12}$")
-plt.plot(ts, cmat[1, 0], 'b', label=r"$c_{21}$")
-plt.plot(ts, cmat[0, 0], 'g', label=r"$c_{11}$")
-plt.plot(ts, cmat[1, 1], 'y', label=r"$c_{22}$")
+plt.plot(ts, covariance_matrix[0, 1], 'r', label=r"$c_{12}$")
+plt.plot(ts, covariance_matrix[1, 0], 'b', label=r"$c_{21}$")
+plt.plot(ts, covariance_matrix[0, 0], 'g', label=r"$c_{11}$")
+plt.plot(ts, covariance_matrix[1, 1], 'y', label=r"$c_{22}$")
 plt.xlabel(r"time $t \; \mathrm{ms}$")
 plt.ylabel(r"$c$")
 plt.legend()

--- a/pynest/examples/cross_check_mip_corrdet.py
+++ b/pynest/examples/cross_check_mip_corrdet.py
@@ -69,7 +69,8 @@ nest.ResetKernel()
 h = 0.1             # Computation step size in ms
 T = 100000.0        # Total duration
 delta_tau = 10.0
-tau_max = 100.0
+tau_max = 100.0  # ms correlation window
+t_bin = 10.0  # ms bin size
 pc = 0.5
 nu = 100.0
 
@@ -102,16 +103,10 @@ nest.Connect(pn2, cd)
 
 nest.Simulate(T)
 
-n_events = cd.get('n_events')
-n1 = n_events[0]
-n2 = n_events[1]
+n_events_1, n_events_2 = cd.n_events
 
-lmbd1 = (n1 / (T - tau_max)) * 1000.0
-lmbd2 = (n2 / (T - tau_max)) * 1000.0
-
-h = 0.1
-tau_max = 100.0  # ms correlation window
-t_bin = 10.0  # ms bin size
+lmbd1 = (n_events_1 / (T - tau_max)) * 1000.0
+lmbd2 = (n_events_2 / (T - tau_max)) * 1000.0
 
 spikes = sd.get('events', 'senders')
 

--- a/pynest/examples/evaluate_quantal_stp_synapse.py
+++ b/pynest/examples/evaluate_quantal_stp_synapse.py
@@ -110,13 +110,12 @@ t2_params['weight'] = 1. / n_syn
 
 nest.SetDefaults("tsodyks2_synapse", t1_params)
 nest.SetDefaults("quantal_stp_synapse", t2_params)
-nest.SetDefaults("iaf_psc_exp", {"tau_syn_ex": 3.})
 
 ###############################################################################
 # We create three different neurons.
 # Neuron one is the sender, the two other neurons receive the synapses.
 
-neuron = nest.Create("iaf_psc_exp", 3)
+neuron = nest.Create("iaf_psc_exp", 3, params={"tau_syn_ex": 3.})
 
 ###############################################################################
 # The connection from neuron 1 to neuron 2 is a deterministic synapse.

--- a/pynest/examples/evaluate_tsodyks2_synapse.py
+++ b/pynest/examples/evaluate_tsodyks2_synapse.py
@@ -92,12 +92,11 @@ t2_params = t1_params.copy()  # for tsodyks2_synapse
 
 nest.SetDefaults("tsodyks2_synapse", t1_params)
 nest.SetDefaults("tsodyks_synapse", t2_params)
-nest.SetDefaults("iaf_psc_exp", {"tau_syn_ex": 3.})
 
 ###############################################################################
 # Create three neurons.
 
-neuron = nest.Create("iaf_psc_exp", 3)
+neuron = nest.Create("iaf_psc_exp", 3, params={"tau_syn_ex": 3.})
 
 ###############################################################################
 # Neuron one produces spikes. Neurons 2 and 3 receive the spikes via the two

--- a/pynest/examples/gap_junctions_inhibitory_network.py
+++ b/pynest/examples/gap_junctions_inhibitory_network.py
@@ -142,8 +142,9 @@ for source_node_id, target_node_id in connections:
 
 nest.Simulate(simtime)
 
-times = sd.get('events', 'times')
-spikes = sd.get('events', 'senders')
+events = sd.events
+times = events['times']
+spikes = events['senders']
 n_spikes = sd.n_events
 
 hz_rate = (1000.0 * n_spikes / simtime) / n_neuron

--- a/pynest/examples/gap_junctions_two_neurons.py
+++ b/pynest/examples/gap_junctions_two_neurons.py
@@ -49,8 +49,8 @@ vm = nest.Create('voltmeter', params={'interval': 0.1})
 # Then we set the constant current input, modify the inital membrane
 # potential of one of the neurons and connect the neurons to the ``voltmeter``.
 
-nest.SetStatus(neuron, {'I_e': 100.})
-nest.SetStatus(neuron[0], {'V_m': -10.})
+neuron.I_e = 100.
+neuron[0].V_m = -10.
 
 nest.Connect(vm, neuron, 'all_to_all')
 
@@ -70,15 +70,15 @@ nest.Connect(neuron, neuron,
 
 nest.Simulate(351.)
 
-senders = nest.GetStatus(vm, 'events')[0]['senders']
-times = nest.GetStatus(vm, 'events')[0]['times']
-V = nest.GetStatus(vm, 'events')[0]['V_m']
+senders = vm.events['senders']
+times = vm.events['times']
+v_m_values = vm.events['V_m']
 
 plt.figure(1)
 plt.plot(times[numpy.where(senders == 1)],
-         V[numpy.where(senders == 1)], 'r-')
+         v_m_values[numpy.where(senders == 1)], 'r-')
 plt.plot(times[numpy.where(senders == 2)],
-         V[numpy.where(senders == 2)], 'g-')
+         v_m_values[numpy.where(senders == 2)], 'g-')
 plt.xlabel('time (ms)')
 plt.ylabel('membrane potential (mV)')
 plt.show()

--- a/pynest/examples/hh_phaseplane.py
+++ b/pynest/examples/hh_phaseplane.py
@@ -67,8 +67,8 @@ neuron = nest.Create('hh_psc_alpha')
 # Numerically obtain equilibrium state
 nest.Simulate(1000)
 
-m_eq = neuron[0].Act_m
-h_eq = neuron[0].Inact_h
+m_eq = neuron.Act_m
+h_eq = neuron.Inact_h
 
 neuron.I_e = amplitude  # Apply external current
 
@@ -87,15 +87,15 @@ for i, V in enumerate(V_vec):
         # Set V_m and n
         neuron.set(V_m=V, Act_n=n, Act_m=m_eq, Inact_h=h_eq)
         # Find state
-        V_m = neuron[0].V_m
-        Act_n = neuron[0].Act_n
+        V_m = neuron.V_m
+        Act_n = neuron.Act_n
 
         # Simulate a short while
         nest.Simulate(dt)
 
         # Find difference between new state and old state
-        V_m_new = neuron[0].V_m - V
-        Act_n_new = neuron[0].Act_n - n
+        V_m_new = neuron.V_m - V
+        Act_n_new = neuron.Act_n - n
 
         # Store in vector for later analysis
         V_matrix[j, i] = abs(V_m_new)
@@ -120,16 +120,16 @@ print('AP-trajectory')
 # ap will contain the trace of a single action potential as one possible
 # numerical solution in the vector field
 ap = np.zeros([1000, 2])
-for i in range(1, 1001):
+for i in range(1000):
     # Find state
-    V_m = neuron[0].V_m
-    Act_n = neuron[0].Act_n
+    V_m = neuron.V_m
+    Act_n = neuron.Act_n
 
     if i % 10 == 0:
         # Write new state next to old state
         print('Vm: \t', V_m)
         print('Act_n:', Act_n)
-    ap[i - 1] = np.array([V_m, Act_n])
+    ap[i] = np.array([V_m, Act_n])
 
     # Simulate again
     neuron.set(Act_m=m_eq, Inact_h=h_eq)

--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -212,13 +212,11 @@ def build_network(logger):
         'resolution': params['dt'],
         'overwrite_files': True})
 
-    nest.SetDefaults('iaf_psc_alpha', model_params)
-
     nest.message(M_INFO, 'build_network', 'Creating excitatory population.')
-    E_neurons = nest.Create('iaf_psc_alpha', NE)
+    E_neurons = nest.Create('iaf_psc_alpha', NE, params=model_params)
 
     nest.message(M_INFO, 'build_network', 'Creating inhibitory population.')
-    I_neurons = nest.Create('iaf_psc_alpha', NI)
+    I_neurons = nest.Create('iaf_psc_alpha', NI, params=model_params)
 
     if brunel_params['randomize_Vm']:
         nest.message(M_INFO, 'build_network',

--- a/pynest/examples/if_curve.py
+++ b/pynest/examples/if_curve.py
@@ -84,12 +84,9 @@ class IF_curve():
         nest.SetKernelStatus({'local_num_threads': self.n_threads})
 
         #######################################################################
-        # We set the default parameters of the neuron model to those
-        # defined above and create neurons and devices.
+        # We create neurons and devices with specified parameters.
 
-        if self.params:
-            nest.SetDefaults(self.model, self.params)
-        self.neuron = nest.Create(self.model, self.n_neurons)
+        self.neuron = nest.Create(self.model, self.n_neurons, self.params if self.params else {})
         self.noise = nest.Create('noise_generator')
         self.spike_detector = nest.Create('spike_detector')
 

--- a/pynest/examples/intrinsic_currents_spiking.py
+++ b/pynest/examples/intrinsic_currents_spiking.py
@@ -134,8 +134,7 @@ nest.Simulate(t_sim)
 # a dictionary with entry ``times`` containing timestamps for all
 # recorded data, plus one entry per recorded quantity.
 # All data is contained in the ``events`` entry of the status dictionary
-# returned by the multimeter. Because all NEST function return arrays,
-# we need to pick out element `0` from the result of ``GetStatus``.
+# returned by the multimeter.
 
 data = mm.events
 t = data['times']

--- a/pynest/examples/intrinsic_currents_subthreshold.py
+++ b/pynest/examples/intrinsic_currents_subthreshold.py
@@ -142,8 +142,7 @@ for t_sim_dep, t_sim_hyp in zip(t_dep, t_hyp):
 # data, plus one entry per recorded quantity.
 #
 # All data is contained in the ``events`` entry of the status dictionary
-# returned by the multimeter. Because all NEST function return arrays,
-# we need to pick out element `0` from the result of ``GetStatus``.
+# returned by the multimeter.
 
 data = mm.events
 t = data['times']
@@ -181,7 +180,9 @@ t_dc, I_dc = [0], [0]
 
 for td, th in zip(t_dep, t_hyp):
     t_prev = t_dc[-1]
-    t_start_dep = t_prev + dt if t_prev > 0 else t_prev + dt + delay
+    t_start_dep = t_prev + dt
+    if t_prev == 0:
+        t_start_dep += delay
     t_end_dep = t_start_dep + td
     t_start_hyp = t_end_dep + dt
     t_end_hyp = t_start_hyp + th

--- a/pynest/examples/lin_rate_ipn_network.py
+++ b/pynest/examples/lin_rate_ipn_network.py
@@ -91,15 +91,10 @@ nest.SetKernelStatus({"resolution": dt, "use_wfr": False,
 print("Building network")
 
 ###############################################################################
-# Configuration of the neuron model using ``SetDefaults``.
-
-nest.SetDefaults(neuron_model, neuron_params)
-
-###############################################################################
 # Creation of the nodes using ``Create``.
 
-n_e = nest.Create(neuron_model, NE)
-n_i = nest.Create(neuron_model, NI)
+n_e = nest.Create(neuron_model, NE, neuron_params)
+n_i = nest.Create(neuron_model, NI, neuron_params)
 
 
 ################################################################################
@@ -143,9 +138,18 @@ nest.Simulate(T)
 # Plot rates of one excitatory and one inhibitory neuron
 
 data = mm.events
-rate_ex = data['rate'][numpy.where(data['senders'] == n_e[0].global_id)]
-rate_in = data['rate'][numpy.where(data['senders'] == n_i[0].global_id)]
-times = data['times'][numpy.where(data['senders'] == n_e[0].global_id)]
+senders = data['senders']
+rate = data['rate']
+times = data['times']
+
+ne_0_id = n_e[0].global_id
+ni_0_id = n_i[0].global_id
+where_sender_is_ne_0 = numpy.where(senders == ne_0_id)
+where_sender_is_ni_0 = numpy.where(senders == ni_0_id)
+
+rate_ex = rate[where_sender_is_ne_0]
+rate_in = rate[where_sender_is_ni_0]
+times = times[where_sender_is_ne_0]
 
 plt.figure()
 plt.plot(times, rate_ex, label='excitatory')

--- a/pynest/examples/mc_neuron.py
+++ b/pynest/examples/mc_neuron.py
@@ -62,23 +62,22 @@ print("iaf_cond_alpha_mc recordables   : {0}".format(rqs))
 ###############################################################################
 # The simulation parameters are assigned to variables.
 
-nest.SetDefaults('iaf_cond_alpha_mc',
-                 {'V_th': -60.0,  # threshold potential
-                  'V_reset': -65.0,  # reset potential
-                  't_ref': 10.0,  # refractory period
-                  'g_sp': 5.0,  # somato-proximal coupling conductance
-                  'soma': {'g_L': 12.0},  # somatic leak conductance
-                  # proximal excitatory and inhibitory synaptic time constants
-                  'proximal': {'tau_syn_ex': 1.0,
-                               'tau_syn_in': 5.0},
-                  'distal': {'C_m': 90.0}  # distal capacitance
-                  })
+params = {'V_th': -60.0,  # threshold potential
+          'V_reset': -65.0,  # reset potential
+          't_ref': 10.0,  # refractory period
+          'g_sp': 5.0,  # somato-proximal coupling conductance
+          'soma': {'g_L': 12.0},  # somatic leak conductance
+          # proximal excitatory and inhibitory synaptic time constants
+          'proximal': {'tau_syn_ex': 1.0,
+                       'tau_syn_in': 5.0},
+          'distal': {'C_m': 90.0}  # distal capacitance
+          }
 
 ###############################################################################
 # The nodes are created using ``Create``. We store the returned handles
 # in variables for later reference.
 
-n = nest.Create('iaf_cond_alpha_mc')
+n = nest.Create('iaf_cond_alpha_mc', params=params)
 
 ###############################################################################
 # A ``multimeter`` is created and connected to the neurons. The parameters
@@ -139,7 +138,7 @@ nest.Simulate(700)
 ###############################################################################
 # Now we set the intrinsic current of soma to 150 pA to make the neuron spike.
 
-n.set({'soma': {'I_e': 150.}})
+n.soma = {'I_e': 150.}
 
 ###############################################################################
 # We simulate the network for another 300 ms and retrieve recorded data from

--- a/pynest/examples/multimeter_file.py
+++ b/pynest/examples/multimeter_file.py
@@ -62,7 +62,7 @@ print("iaf_cond_alpha recordables: {0}".format(
       nest.GetDefaults("iaf_cond_alpha")["recordables"]))
 
 ###############################################################################
-# A neuron, a multimeter as recording device and two spike generators for
+# A neuron, a multimeter as recording device, and two spike generators for
 # excitatory and inhibitory stimulation are instantiated. The command ``Create``
 # expects a model type and, optionally, the desired number of nodes and a
 # dictionary of parameters to overwrite the default values of the model.
@@ -101,7 +101,7 @@ s_in = nest.Create("spike_generator",
                    params={"spike_times": numpy.array([15.0, 25.0, 55.0])})
 
 ###############################################################################
-# Next, We connect the spike generators to the neuron with ``Connect``. Synapse
+# Next, we connect the spike generators to the neuron with ``Connect``. Synapse
 # specifications can be provided in a dictionary. In this example of a
 # conductance-based neuron, the synaptic weight ``weight`` is given in nS.
 # Note that the values are  positive for excitatory stimulation and negative
@@ -120,7 +120,7 @@ nest.Simulate(100.)
 # After the simulation, the recordings are obtained from the file the
 # multimeter wrote to, accessed with the `filenames` property of the
 # multimeter. After three header rows, the data is formatted in columns. The
-# first column is the ID of the sender node. The second column is the ID time
+# first column is the ID of the sender node. The second column is the time
 # of the recording, in ms. Subsequent rows are values of properties specified
 # in the `record_from` property of the multimeter.
 

--- a/pynest/examples/one_neuron_with_noise.py
+++ b/pynest/examples/one_neuron_with_noise.py
@@ -59,7 +59,8 @@ voltmeter = nest.Create("voltmeter")
 # not need to set parameters for the neuron and the voltmeter, since they have
 # satisfactory defaults.
 
-noise.set([{"rate": 80000.0}, {"rate": 15000.0}])
+noise[0].rate = 80000.0
+noise[1].rate = 15000.0
 
 ###############################################################################
 # Fourth, the neuron is connected to the ``poisson_generator`` and to the

--- a/pynest/examples/sinusoidal_gamma_generator.py
+++ b/pynest/examples/sinusoidal_gamma_generator.py
@@ -65,14 +65,15 @@ nest.SetKernelStatus({'resolution': 0.01})
 # (``spike_detector``) and connect them to the generators using ``Connect``.
 
 
-g = nest.Create('sinusoidal_gamma_generator', n=2,
+num_nodes = 2
+g = nest.Create('sinusoidal_gamma_generator', n=num_nodes,
                 params=[{'rate': 10000.0, 'amplitude': 5000.0,
                          'frequency': 10.0, 'phase': 0.0, 'order': 2.0},
                         {'rate': 10000.0, 'amplitude': 5000.0,
                          'frequency': 10.0, 'phase': 0.0, 'order': 10.0}])
 
-m = nest.Create('multimeter', 2, {'interval': 0.1, 'record_from': ['rate']})
-s = nest.Create('spike_detector', 2)
+m = nest.Create('multimeter', num_nodes, {'interval': 0.1, 'record_from': ['rate']})
+s = nest.Create('spike_detector', num_nodes)
 
 nest.Connect(m, g, 'one_to_one')
 nest.Connect(g, s, 'one_to_one')
@@ -81,27 +82,27 @@ nest.Simulate(200)
 
 
 ###############################################################################
-# After simulating, the spikes are extracted from the ``spike_detector`` using
-# ``GetStatus`` and plots are created with panels for the PST and ISI histograms.
+# After simulating, the spikes are extracted from the ``spike_detector`` and
+# plots are created with panels for the PST and ISI histograms.
 
 colors = ['b', 'g']
 
-for j in range(2):
+for j in range(num_nodes):
 
     ev = m[j].events
     t = ev['times']
     r = ev['rate']
 
-    sp = nest.GetStatus(s[j])[0]['events']['times']
+    spike_times = s[j].events['times']
     plt.subplot(221)
-    h, e = np.histogram(sp, bins=np.arange(0., 201., 5.))
+    h, e = np.histogram(spike_times, bins=np.arange(0., 201., 5.))
     plt.plot(t, r, color=colors[j])
     plt.step(e[:-1], h * 1000 / 5., color=colors[j], where='post')
     plt.title('PST histogram and firing rates')
     plt.ylabel('Spikes per second')
 
     plt.subplot(223)
-    plt.hist(np.diff(sp), bins=np.arange(0., 0.505, 0.01),
+    plt.hist(np.diff(spike_times), bins=np.arange(0., 0.505, 0.01),
              histtype='step', color=colors[j])
     plt.title('ISI histogram')
 

--- a/pynest/examples/sinusoidal_poisson_generator.py
+++ b/pynest/examples/sinusoidal_poisson_generator.py
@@ -56,7 +56,8 @@ nest.ResetKernel()   # in case we run the script multiple times from iPython
 
 nest.SetKernelStatus({'resolution': 0.01})
 
-g = nest.Create('sinusoidal_poisson_generator', n=2,
+num_nodes = 2
+g = nest.Create('sinusoidal_poisson_generator', n=num_nodes,
                 params=[{'rate': 10000.0,
                          'amplitude': 5000.0,
                          'frequency': 10.0,
@@ -66,8 +67,8 @@ g = nest.Create('sinusoidal_poisson_generator', n=2,
                          'frequency': 5.0,
                          'phase': 90.0}])
 
-m = nest.Create('multimeter', 2, {'interval': 0.1, 'record_from': ['rate']})
-s = nest.Create('spike_detector', 2)
+m = nest.Create('multimeter', num_nodes, {'interval': 0.1, 'record_from': ['rate']})
+s = nest.Create('spike_detector', num_nodes)
 
 nest.Connect(m, g, 'one_to_one')
 nest.Connect(g, s, 'one_to_one')
@@ -76,28 +77,28 @@ nest.Simulate(200)
 
 
 ###############################################################################
-# After simulating, the spikes are extracted from the ``spike_detector`` using
-# ``GetStatus`` and plots are created with panels for the PST and ISI histograms.
+# After simulating, the spikes are extracted from the ``spike_detector`` and
+# plots are created with panels for the PST and ISI histograms.
 
 
 colors = ['b', 'g']
 
-for j in range(2):
+for j in range(num_nodes):
 
     ev = m[j].events
     t = ev['times']
     r = ev['rate']
 
-    sp = nest.GetStatus(s[j])[0]['events']['times']
+    spike_times = s[j].events['times']
     plt.subplot(221)
-    h, e = np.histogram(sp, bins=np.arange(0., 201., 5.))
+    h, e = np.histogram(spike_times, bins=np.arange(0., 201., 5.))
     plt.plot(t, r, color=colors[j])
     plt.step(e[:-1], h * 1000 / 5., color=colors[j], where='post')
     plt.title('PST histogram and firing rates')
     plt.ylabel('Spikes per second')
 
     plt.subplot(223)
-    plt.hist(np.diff(sp), bins=np.arange(0., 1.005, 0.02),
+    plt.hist(np.diff(spike_times), bins=np.arange(0., 1.005, 0.02),
              histtype='step', color=colors[j])
     plt.title('ISI histogram')
 

--- a/pynest/examples/structural_plasticity.py
+++ b/pynest/examples/structural_plasticity.py
@@ -246,9 +246,9 @@ class StructralPlasticityExample:
 
 ####################################################################################
 # In order to save the amount of average calcium concentration in each
-# population through time we create the function ``record_ca``. Here we use the
-# ``GetStatus`` function to retrieve the value of `Ca` for every neuron in the
-# network and then store the average.
+# population through time we create the function ``record_ca``. Here we use
+# the retrieve the value of `Ca` for every neuron in the network and then
+# store the average.
 
     def record_ca(self):
         ca_e = self.nodes_e.Ca,  # Calcium concentration
@@ -260,11 +260,10 @@ class StructralPlasticityExample:
 
 ####################################################################################
 # In order to save the state of the connectivity in the network through time
-# we create the function ``record_connectivity``. Here we use the ``GetStatus``
-# function to retrieve the number of connected pre-synaptic elements of each
-# neuron. The total amount of excitatory connections is equal to the total
-# amount of connected excitatory pre-synaptic elements. The same applies for
-# inhibitory connections.
+# we create the function ``record_connectivity``. Here we retrieve the number
+# of connected pre-synaptic elements of each neuron. The total amount of
+# excitatory connections is equal to the total amount of connected excitatory
+# pre-synaptic elements. The same applies for inhibitory connections.
 
     def record_connectivity(self):
         syn_elems_e = self.nodes_e.synaptic_elements

--- a/pynest/examples/vinit_example.py
+++ b/pynest/examples/vinit_example.py
@@ -71,8 +71,7 @@ for vinit in numpy.arange(-100, -50, 10, float):
     nest.ResetKernel()
 
     cbn = nest.Create("iaf_cond_exp_sfa_rr")
-
-    nest.SetStatus(cbn, "V_m", vinit)
+    cbn.V_m = vinit
 
     voltmeter = nest.Create("voltmeter")
     nest.Connect(voltmeter, cbn)


### PR DESCRIPTION
- I have left using `set()` with keyword arguments (`nodes.set(V_m=var1, ...)`) unchanged, as this is a new NEST 3 feature. 
- Using `get()` with two arguments (e.g. `sp.get('events', 'times')`) is a new NEST 3 feature, so I have mostly left those unchanged as well. But with the new dot notation we may want to remove the two argument version again, as we can then write just `sp.events['times']` instead.
- There are still some places where synapse parameters are set using `SetDefaults()`. They can probably be moved into the `Connect()` functions.