### PR TITLE
Replace CopyModel in PyNEST examples

### DIFF
--- a/pynest/examples/CampbellSiegert.py
+++ b/pynest/examples/CampbellSiegert.py
@@ -176,9 +176,8 @@ neurondict = {'V_th': V_th,
 # free membrane potential. In addition we choose a small resolution for
 # recording the membrane to collect good statistics.
 
-nest.SetDefaults('iaf_psc_alpha', neurondict)
-n = nest.Create('iaf_psc_alpha', n_neurons)
-n_free = nest.Create('iaf_psc_alpha', params={'V_th': 1e12})
+n = nest.Create('iaf_psc_alpha', n_neurons, params=neurondict)
+n_free = nest.Create('iaf_psc_alpha', params=dict(neurondict, V_th=1e12))
 pg = nest.Create('poisson_generator', len(rates), {'rate': rates})
 vm = nest.Create('voltmeter', params={'interval': .1})
 sr = nest.Create('spike_recorder')

--- a/pynest/examples/cross_check_mip_corrdet.py
+++ b/pynest/examples/cross_check_mip_corrdet.py
@@ -95,11 +95,8 @@ nest.Connect(mg, pn2)
 nest.Connect(pn1, sr)
 nest.Connect(pn2, sr)
 
-nest.SetDefaults('static_synapse', {'weight': 1.0, 'receptor_type': 0})
-nest.Connect(pn1, cd)
-
-nest.SetDefaults('static_synapse', {'weight': 1.0, 'receptor_type': 1})
-nest.Connect(pn2, cd)
+nest.Connect(pn1, cd, syn_spec={'weight': 1.0, 'receptor_type': 0})
+nest.Connect(pn2, cd, syn_spec={'weight': 1.0, 'receptor_type': 1})
 
 nest.Simulate(T)
 

--- a/pynest/examples/evaluate_quantal_stp_synapse.py
+++ b/pynest/examples/evaluate_quantal_stp_synapse.py
@@ -93,23 +93,23 @@ fac_params = {"U": 0.02, "u": 0.02, "tau_fac": 500.,
 ###############################################################################
 # Then, we assign the parameter set to the synapse models
 
-t1_params = fac_params  # for tsodyks2_synapse
-t2_params = t1_params.copy()  # for quantal_stp_synapse
+tsodyks_params = dict(fac_params, synapse_model="tsodyks2_synapse")  # for tsodyks2_synapse
+quantal_params = fac_params.copy()  # for quantal_stp_synapse
 
-t1_params['x'] = t1_params['U']
-t2_params['n'] = n_syn
+tsodyks_params['x'] = tsodyks_params['U']
+quantal_params['n'] = n_syn
 
 ###############################################################################
 # To make the responses comparable, we have to scale the weight by the
 # number of synapses.
 
-t2_params['weight'] = 1. / n_syn
+quantal_params['weight'] = 1. / n_syn
 
 ###############################################################################
-# Next, we chage the defaults of the various models to our parameters.
+# Next, we change the defaults of the quantal_stdp_synapse model to our parameters,
+# because it doesn't support the setting of parameter n in syn_spec.
 
-nest.SetDefaults("tsodyks2_synapse", t1_params)
-nest.SetDefaults("quantal_stp_synapse", t2_params)
+nest.SetDefaults("quantal_stp_synapse", quantal_params)
 
 ###############################################################################
 # We create three different neurons.
@@ -120,7 +120,7 @@ neuron = nest.Create("iaf_psc_exp", 3, params={"tau_syn_ex": 3.})
 ###############################################################################
 # The connection from neuron 1 to neuron 2 is a deterministic synapse.
 
-nest.Connect(neuron[0], neuron[1], syn_spec="tsodyks2_synapse")
+nest.Connect(neuron[0], neuron[1], syn_spec=tsodyks_params)
 
 ###############################################################################
 # The connection from neuron 1 to neuron 3 has a stochastic

--- a/pynest/examples/evaluate_quantal_stp_synapse.py
+++ b/pynest/examples/evaluate_quantal_stp_synapse.py
@@ -31,7 +31,7 @@ facilitation according to the quantal release model described by Fuhrmann et
 al. [1]_ and Loebel et al. [2]_.
 
 Each presynaptic spike will stochastically activate a fraction of the
-available release sites.  This fraction is binomialy distributed and the
+available release sites.  This fraction is binomially distributed and the
 release probability per site is governed by the Fuhrmann et al. (2002) model.
 The solution of the differential equations is taken from Maass and Markram
 2002 [3]_.
@@ -185,7 +185,7 @@ plt.plot(vm_ref_mean)
 plt.show()
 
 ###############################################################################
-# Finally, print the mean-suqared error between the trial-average and the
+# Finally, print the mean-squared error between the trial-average and the
 # reference trace. The value should be `< 10^-9`.
 
 print(numpy.mean((vm_ref_mean - vm_mean) ** 2))

--- a/pynest/examples/evaluate_tsodyks2_synapse.py
+++ b/pynest/examples/evaluate_tsodyks2_synapse.py
@@ -88,11 +88,8 @@ fac_params = {"U": 0.1, "u": 0.1, 'x': 1.0, "tau_fac": 1000.,
 ###############################################################################
 # Now we assign the parameter set to the synapse models.
 
-t1_params = fac_params       # for tsodyks_synapse
-t2_params = t1_params.copy()  # for tsodyks2_synapse
-
-nest.SetDefaults("tsodyks2_synapse", t1_params)
-nest.SetDefaults("tsodyks_synapse", t2_params)
+tsodyks_params = dict(fac_params, synapse_model="tsodyks_synapse")  # for tsodyks_synapse
+tsodyks2_params = dict(fac_params, synapse_model="tsodyks2_synapse")  # for tsodyks2_synapse
 
 ###############################################################################
 # Create three neurons.
@@ -103,8 +100,8 @@ neuron = nest.Create("iaf_psc_exp", 3, params={"tau_syn_ex": 3.})
 # Neuron one produces spikes. Neurons 2 and 3 receive the spikes via the two
 # synapse models.
 
-nest.Connect(neuron[0], neuron[1], syn_spec="tsodyks_synapse")
-nest.Connect(neuron[0], neuron[2], syn_spec="tsodyks2_synapse")
+nest.Connect(neuron[0], neuron[1], syn_spec=tsodyks_params)
+nest.Connect(neuron[0], neuron[2], syn_spec=tsodyks2_params)
 
 ###############################################################################
 # Now create two voltmeters to record the responses.

--- a/pynest/examples/gif_pop_psc_exp.py
+++ b/pynest/examples/gif_pop_psc_exp.py
@@ -171,8 +171,7 @@ nest_sr = []
 for i in range(M):
     nest_sr.append(nest.Create('spike_recorder'))
     nest_sr[i].time_in_steps = True
-    nest.SetDefaults('static_synapse', {'weight': 1., 'delay': dt})
-    nest.Connect(nest_pops[i], nest_sr[i])
+    nest.Connect(nest_pops[i], nest_sr[i], syn_spec={'weight': 1., 'delay': dt})
 
 ###############################################################################
 # All neurons in a given population will be stimulated with a step input
@@ -191,7 +190,7 @@ for i in range(M):
                             origin=t0,
                             stop=t_end)
     pop_ = nest_pops[i]
-    nest.Connect(nest_stepcurrent[i], pop_, syn_spec={'weight': 1.})
+    nest.Connect(nest_stepcurrent[i], pop_, syn_spec={'weight': 1., 'delay': dt})
 
 ###############################################################################
 # We can now start the simulation:
@@ -304,7 +303,7 @@ for i, nest_i in enumerate(nest_pops):
     nest_mm_Vm.append(nest.Create('multimeter'))
     nest_mm_Vm[i].set(record_from=['V_m'], interval=dt_rec)
     if Nrecord[i] != 0:
-        nest.Connect(nest_mm_Vm[i], nest_i[:Nrecord[i]])
+        nest.Connect(nest_mm_Vm[i], nest_i[:Nrecord[i]], syn_spec={'weight': 1., 'delay': dt})
 
 ###############################################################################
 # As before, all neurons in a given population will be stimulated with a
@@ -325,7 +324,7 @@ for i in range(M):
                             stop=t_end)
     # optionally a stopping time may be added by: 'stop': sim_T + t0
     pop_ = nest_pops[i]
-    nest.Connect(nest_stepcurrent[i], pop_, syn_spec={'weight': 1.})
+    nest.Connect(nest_stepcurrent[i], pop_, syn_spec={'weight': 1., 'delay': dt})
 
 ###############################################################################
 # We can now start the microscopic simulation:

--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -125,7 +125,7 @@ def convert_synapse_weight(tau_m, tau_syn, C_m):
     return 1. / v_max
 
 ###############################################################################
-# For compatiblity with earlier benchmarks, we require a rise time of
+# For compatibility with earlier benchmarks, we require a rise time of
 # ``t_rise = 1.700759 ms`` and we choose ``tau_syn`` to achieve this for given
 # ``tau_m``. This requires numerical inversion of the expression for ``t_rise``
 # in ``convert_synapse_weight``. We computed this value once and hard-code

--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -268,7 +268,6 @@ def build_network(logger):
     tic = time.time()
 
     nest.SetDefaults('static_synapse_hpc', {'delay': brunel_params['delay']})
-    nest.CopyModel('static_synapse_hpc', 'syn_std')
     nest.CopyModel('static_synapse_hpc', 'syn_ex',
                    {'weight': JE_pA})
     nest.CopyModel('static_synapse_hpc', 'syn_in',

--- a/pynest/examples/pulsepacket.py
+++ b/pynest/examples/pulsepacket.py
@@ -227,9 +227,7 @@ vm = nest.Create('voltmeter', params=vm_pars)
 
 ###############################################################################
 # Now, we connect each pulse generator to one neuron via static synapses.
-# We want to keep all properties of the static synapse constant except the
-# synaptic weight. Therefore we change the weight with  the help of the command
-# ``SetDefaults``.
+# We use the default static synapse, with specified weight.
 # The command ``Connect`` connects all kinds of nodes/devices. Since multiple
 # nodes/devices can be connected in different ways e.g., each source connects
 # to all targets, each source connects to a subset of targets or each source
@@ -238,9 +236,8 @@ vm = nest.Create('voltmeter', params=vm_pars)
 # generator (source) to one neuron (target).
 # In addition we also connect the `voltmeter` to the `neurons`.
 
-nest.SetDefaults('static_synapse', {'weight': weight})
-nest.Connect(ppgs, neurons, 'one_to_one')
-nest.Connect(vm, neurons)
+nest.Connect(ppgs, neurons, 'one_to_one', syn_spec={'weight': weight})
+nest.Connect(vm, neurons, syn_spec={'weight': weight})
 
 
 ###############################################################################

--- a/pynest/examples/urbanczik_synapse_example.py
+++ b/pynest/examples/urbanczik_synapse_example.py
@@ -248,8 +248,7 @@ nest.SetKernelStatus({'resolution': resolution})
 '''
 neuron and devices
 '''
-nest.SetDefaults(nrn_model, nrn_params)
-nrn = nest.Create(nrn_model)
+nrn = nest.Create(nrn_model, params=nrn_params)
 
 # poisson generators are connected to parrot neurons which are
 # connected to the mc neuron


### PR DESCRIPTION
Most of the `CopyModel` calls are replaced with directly specifying the parameters in `Create()` or `Connect()`. I didn't change the calls in `hpc_benchmark.py` because I think using `CopyModel` there is actually less complicated than the alternative. I also didn't change  `structural_plasticity.py` because it looks like `CopyModel` is needed there.