### PR TITLE
Update PyNEST examples

### DIFF
--- a/pynest/examples/CampbellSiegert.py
+++ b/pynest/examples/CampbellSiegert.py
@@ -200,9 +200,6 @@ nest.Simulate(simtime)
 
 v_free = vm.events['V_m']
 Nskip = 500
-print('mean membrane potential (actual / calculated): {0} / {1}'
-      .format(np.mean(v_free[Nskip:]), mu * 1000))
-print('variance (actual / calculated): {0} / {1}'
-      .format(np.var(v_free[Nskip:]), sigma2 * 1e6))
-print('firing rate (actual / calculated): {0} / {1}'
-      .format(sr.n_events / (n_neurons * simtime * ms), r))
+print(f'mean membrane potential (actual / calculated): {np.mean(v_free[Nskip:])} / {mu * 1000}')
+print(f'variance (actual / calculated): {np.var(v_free[Nskip:])} / {sigma2 * 1e6}')
+print(f'firing rate (actual / calculated): {sr.n_events / (n_neurons * simtime * ms)} / {r}')

--- a/pynest/examples/aeif_cond_beta_multisynapse.py
+++ b/pynest/examples/aeif_cond_beta_multisynapse.py
@@ -43,7 +43,7 @@ voltmeter = nest.Create('voltmeter')
 delays = [1.0, 300.0, 500.0, 700.0]
 w = [1.0, 1.0, 1.0, 1.0]
 for syn in range(4):
-    nest.Connect(spike, neuron, syn_spec={'model': 'static_synapse',
+    nest.Connect(spike, neuron, syn_spec={'synapse_model': 'static_synapse',
                                           'receptor_type': 1 + syn,
                                           'weight': w[syn],
                                           'delay': delays[syn]})

--- a/pynest/examples/aeif_cond_beta_multisynapse.py
+++ b/pynest/examples/aeif_cond_beta_multisynapse.py
@@ -28,6 +28,7 @@ aeif_cond_beta_multisynapse
 
 import nest
 import numpy as np
+import matplotlib.pyplot as plt
 
 neuron = nest.Create('aeif_cond_beta_multisynapse')
 nest.SetStatus(neuron, {"V_peak": 0.0, "a": 4.0, "b": 80.5})
@@ -55,7 +56,5 @@ nest.Simulate(1000.0)
 Vms = voltmeter.get("events", "V_m")
 ts = voltmeter.get("events", "times")
 
-# import pylab
-# pylab.figure(2)
-# pylab.plot(ts, Vms)
-# pylab.show()
+plt.plot(ts, Vms)
+plt.show()

--- a/pynest/examples/aeif_cond_beta_multisynapse.py
+++ b/pynest/examples/aeif_cond_beta_multisynapse.py
@@ -52,9 +52,8 @@ nest.Connect(voltmeter, neuron)
 
 nest.Simulate(1000.0)
 
-dmm = nest.GetStatus(voltmeter)[0]
-Vms = dmm["events"]["V_m"]
-ts = dmm["events"]["times"]
+Vms = voltmeter.get("events", "V_m")
+ts = voltmeter.get("events", "times")
 
 # import pylab
 # pylab.figure(2)

--- a/pynest/examples/brunel_alpha_evolution_strategies.py
+++ b/pynest/examples/brunel_alpha_evolution_strategies.py
@@ -247,14 +247,10 @@ def simulate(parameters):
 
     if parameters['N_rec'] > NE:
         raise ValueError(
-            'Requested recording from {} neurons, \
-            but only {} in excitatory population'.format(
-                parameters['N_rec'], NE))
+            f'Requested recording from {parameters["N_rec"]} neurons, but only {NE} in excitatory population')
     if parameters['N_rec'] > NI:
         raise ValueError(
-            'Requested recording from {} neurons, \
-            but only {} in inhibitory population'.format(
-                parameters['N_rec'], NI))
+            f'Requested recording from {parameters["N_rec"]} neurons, but only {NI} in inhibitory population')
     nest.Connect(nodes_ex[:parameters['N_rec']], espikes)
     nest.Connect(nodes_in[:parameters['N_rec']], ispikes)
 
@@ -396,11 +392,10 @@ def optimize(func, mu, sigma, learning_rate_mu=None, learning_rate_sigma=None,
         # print status if enabled
         if verbosity > 0:
             print(
-                '# Generation {:d} | fitness {:.3f} | mu {} | sigma {}'.format(
-                    generation, np.mean(fitness),
-                    ', '.join(str(np.round(mu_i, 3)) for mu_i in mu),
-                    ', '.join(str(np.round(sigma_i, 3)) for sigma_i in sigma)
-                ))
+                f'# Generation {generation:d} | fitness {np.mean(fitness):.3f} | '
+                f'mu {", ".join(str(np.round(mu_i, 3)) for mu_i in mu)} | '
+                f'sigma {", ".join(str(np.round(sigma_i, 3)) for sigma_i in sigma)}'
+            )
 
         # apply fitness shaping if enabled
         if fitness_shaping:

--- a/pynest/examples/brunel_alpha_evolution_strategies.py
+++ b/pynest/examples/brunel_alpha_evolution_strategies.py
@@ -347,7 +347,7 @@ def optimize(func, mu, sigma, learning_rate_mu=None, learning_rate_sigma=None,
     # min_sigma: float
     #     Minimal value for standard deviation of search
     #     distribution. If any dimension has a value smaller than this,
-    #     the search is stoppped.
+    #     the search is stopped.
     # verbosity: bool
     #     Whether to continuously print progress information.
     #

--- a/pynest/examples/brunel_alpha_evolution_strategies.py
+++ b/pynest/examples/brunel_alpha_evolution_strategies.py
@@ -455,9 +455,9 @@ def optimize_network(optimization_parameters, simulation_parameters):
         rate, cv, corr = compute_statistics(
             simulation_parameters, espikes, ispikes)
         fitness = (
-            -optimization_parameters['fitness_weight_rate'] * (rate - optimization_parameters['target_rate'])**2
-            - optimization_parameters['fitness_weight_cv'] * (cv - optimization_parameters['target_cv'])**2
-            - optimization_parameters['fitness_weight_corr'] * (corr - optimization_parameters['target_corr'])**2
+            -optimization_parameters['fitness_weight_rate'] * (rate - optimization_parameters['target_rate'])**2 -
+            optimization_parameters['fitness_weight_cv'] * (cv - optimization_parameters['target_cv'])**2 -
+            optimization_parameters['fitness_weight_corr'] * (corr - optimization_parameters['target_corr'])**2
         )
 
         return fitness

--- a/pynest/examples/brunel_alpha_evolution_strategies.py
+++ b/pynest/examples/brunel_alpha_evolution_strategies.py
@@ -454,13 +454,11 @@ def optimize_network(optimization_parameters, simulation_parameters):
         # analyse the result and compute fitness
         rate, cv, corr = compute_statistics(
             simulation_parameters, espikes, ispikes)
-        fitness = \
-            - optimization_parameters['fitness_weight_rate'] * (
-                rate - optimization_parameters['target_rate']) ** 2 \
-            - optimization_parameters['fitness_weight_cv'] * (
-                cv - optimization_parameters['target_cv']) ** 2 \
-            - optimization_parameters['fitness_weight_corr'] * (
-                corr - optimization_parameters['target_corr']) ** 2
+        fitness = (
+            -optimization_parameters['fitness_weight_rate'] * (rate - optimization_parameters['target_rate'])**2
+            - optimization_parameters['fitness_weight_cv'] * (cv - optimization_parameters['target_cv'])**2
+            - optimization_parameters['fitness_weight_corr'] * (corr - optimization_parameters['target_corr'])**2
+        )
 
         return fitness
 

--- a/pynest/examples/brunel_alpha_nest.py
+++ b/pynest/examples/brunel_alpha_nest.py
@@ -82,9 +82,9 @@ def ComputePSPnorm(tauMem, CMem, tauSyn):
     t_max = 1.0 / b * (-LambertWm1(-np.exp(-1.0 / a) / a) - 1.0 / a)
 
     # maximum of PSP for current of unit amplitude
-    return (np.exp(1.0) / (tauSyn * CMem * b) *
-            ((np.exp(-t_max / tauMem) - np.exp(-t_max / tauSyn)) / b -
-             t_max * np.exp(-t_max / tauSyn)))
+    return (np.exp(1.0) / (tauSyn * CMem * b)
+            * ((np.exp(-t_max / tauMem) - np.exp(-t_max / tauSyn)) / b
+               - t_max * np.exp(-t_max / tauSyn)))
 
 
 nest.ResetKernel()
@@ -293,8 +293,8 @@ rate_in = events_in / simtime * 1000.0 / N_rec
 # inhibitory synapse model. The numbers are summed up resulting in the total
 # number of synapses.
 
-num_synapses = (nest.GetDefaults("excitatory")["num_connections"] +
-                nest.GetDefaults("inhibitory")["num_connections"])
+num_synapses = (nest.GetDefaults("excitatory")["num_connections"]
+                + nest.GetDefaults("inhibitory")["num_connections"])
 
 ###############################################################################
 # Establishing the time it took to build and simulate the network by taking

--- a/pynest/examples/brunel_alpha_nest.py
+++ b/pynest/examples/brunel_alpha_nest.py
@@ -307,14 +307,14 @@ sim_time = endsimulate - endbuild
 # Printing the network properties, firing rates and building times.
 
 print("Brunel network simulation (Python)")
-print("Number of neurons : {0}".format(N_neurons))
-print("Number of synapses: {0}".format(num_synapses))
-print("       Exitatory  : {0}".format(int(CE * N_neurons) + N_neurons))
-print("       Inhibitory : {0}".format(int(CI * N_neurons)))
-print("Excitatory rate   : %.2f Hz" % rate_ex)
-print("Inhibitory rate   : %.2f Hz" % rate_in)
-print("Building time     : %.2f s" % build_time)
-print("Simulation time   : %.2f s" % sim_time)
+print(f"Number of neurons : {N_neurons}")
+print(f"Number of synapses: {num_synapses}")
+print(f"       Exitatory  : {int(CE * N_neurons) + N_neurons}")
+print(f"       Inhibitory : {int(CI * N_neurons)}")
+print(f"Excitatory rate   : {rate_ex:.2f} Hz")
+print(f"Inhibitory rate   : {rate_in:.2f} Hz")
+print(f"Building time     : {build_time:.2f} s")
+print(f"Simulation time   : {sim_time:.2f} s")
 
 ###############################################################################
 # Plot a raster of the excitatory neurons and a histogram.

--- a/pynest/examples/brunel_alpha_nest.py
+++ b/pynest/examples/brunel_alpha_nest.py
@@ -82,9 +82,9 @@ def ComputePSPnorm(tauMem, CMem, tauSyn):
     t_max = 1.0 / b * (-LambertWm1(-np.exp(-1.0 / a) / a) - 1.0 / a)
 
     # maximum of PSP for current of unit amplitude
-    return (np.exp(1.0) / (tauSyn * CMem * b)
-            * ((np.exp(-t_max / tauMem) - np.exp(-t_max / tauSyn)) / b
-               - t_max * np.exp(-t_max / tauSyn)))
+    return (np.exp(1.0) / (tauSyn * CMem * b) *
+            ((np.exp(-t_max / tauMem) - np.exp(-t_max / tauSyn)) / b -
+             t_max * np.exp(-t_max / tauSyn)))
 
 
 nest.ResetKernel()
@@ -293,8 +293,8 @@ rate_in = events_in / simtime * 1000.0 / N_rec
 # inhibitory synapse model. The numbers are summed up resulting in the total
 # number of synapses.
 
-num_synapses = (nest.GetDefaults("excitatory")["num_connections"]
-                + nest.GetDefaults("inhibitory")["num_connections"])
+num_synapses = (nest.GetDefaults("excitatory")["num_connections"] +
+                nest.GetDefaults("inhibitory")["num_connections"])
 
 ###############################################################################
 # Establishing the time it took to build and simulate the network by taking

--- a/pynest/examples/brunel_delta_nest.py
+++ b/pynest/examples/brunel_delta_nest.py
@@ -248,8 +248,8 @@ rate_in = events_in / simtime * 1000.0 / N_rec
 # inhibitory synapse model. The numbers are summed up resulting in the total
 # number of synapses.
 
-num_synapses = (nest.GetDefaults("excitatory")["num_connections"]
-                + nest.GetDefaults("inhibitory")["num_connections"])
+num_synapses = (nest.GetDefaults("excitatory")["num_connections"] +
+                nest.GetDefaults("inhibitory")["num_connections"])
 
 ###############################################################################
 # Establishing the time it took to build and simulate the network by taking

--- a/pynest/examples/brunel_delta_nest.py
+++ b/pynest/examples/brunel_delta_nest.py
@@ -248,8 +248,8 @@ rate_in = events_in / simtime * 1000.0 / N_rec
 # inhibitory synapse model. The numbers are summed up resulting in the total
 # number of synapses.
 
-num_synapses = (nest.GetDefaults("excitatory")["num_connections"] +
-                nest.GetDefaults("inhibitory")["num_connections"])
+num_synapses = (nest.GetDefaults("excitatory")["num_connections"]
+                + nest.GetDefaults("inhibitory")["num_connections"])
 
 ###############################################################################
 # Establishing the time it took to build and simulate the network by taking

--- a/pynest/examples/brunel_delta_nest.py
+++ b/pynest/examples/brunel_delta_nest.py
@@ -262,14 +262,14 @@ sim_time = endsimulate - endbuild
 # Printing the network properties, firing rates and building times.
 
 print("Brunel network simulation (Python)")
-print("Number of neurons : {0}".format(N_neurons))
-print("Number of synapses: {0}".format(num_synapses))
-print("       Exitatory  : {0}".format(int(CE * N_neurons) + N_neurons))
-print("       Inhibitory : {0}".format(int(CI * N_neurons)))
-print("Excitatory rate   : %.2f Hz" % rate_ex)
-print("Inhibitory rate   : %.2f Hz" % rate_in)
-print("Building time     : %.2f s" % build_time)
-print("Simulation time   : %.2f s" % sim_time)
+print(f"Number of neurons : {N_neurons}")
+print(f"Number of synapses: {num_synapses}")
+print(f"       Exitatory  : {int(CE * N_neurons) + N_neurons}")
+print(f"       Inhibitory : {int(CI * N_neurons)}")
+print(f"Excitatory rate   : {rate_ex:.2f} Hz")
+print(f"Inhibitory rate   : {rate_in:.2f} Hz")
+print(f"Building time     : {build_time:.2f} s")
+print(f"Simulation time   : {sim_time:.2f} s")
 
 ###############################################################################
 # Plot a raster of the excitatory neurons and a histogram.

--- a/pynest/examples/brunel_exp_multisynapse_nest.py
+++ b/pynest/examples/brunel_exp_multisynapse_nest.py
@@ -277,8 +277,8 @@ rate_in = events_in / simtime * 1000.0 / N_rec
 # inhibitory synapse model. The numbers are summed up resulting in the total
 # number of synapses.
 
-num_synapses = (nest.GetDefaults("excitatory")["num_connections"]
-                + nest.GetDefaults("inhibitory")["num_connections"])
+num_synapses = (nest.GetDefaults("excitatory")["num_connections"] +
+                nest.GetDefaults("inhibitory")["num_connections"])
 
 ###############################################################################
 # Establishing the time it took to build and simulate the network by taking

--- a/pynest/examples/brunel_exp_multisynapse_nest.py
+++ b/pynest/examples/brunel_exp_multisynapse_nest.py
@@ -277,8 +277,8 @@ rate_in = events_in / simtime * 1000.0 / N_rec
 # inhibitory synapse model. The numbers are summed up resulting in the total
 # number of synapses.
 
-num_synapses = (nest.GetDefaults("excitatory")["num_connections"] +
-                nest.GetDefaults("inhibitory")["num_connections"])
+num_synapses = (nest.GetDefaults("excitatory")["num_connections"]
+                + nest.GetDefaults("inhibitory")["num_connections"])
 
 ###############################################################################
 # Establishing the time it took to build and simulate the network by taking

--- a/pynest/examples/brunel_exp_multisynapse_nest.py
+++ b/pynest/examples/brunel_exp_multisynapse_nest.py
@@ -291,14 +291,14 @@ sim_time = endsimulate - endbuild
 # Printing the network properties, firing rates and building times.
 
 print("Brunel network simulation (Python)")
-print("Number of neurons : {0}".format(N_neurons))
-print("Number of synapses: {0}".format(num_synapses))
-print("       Exitatory  : {0}".format(int(CE * N_neurons) + N_neurons))
-print("       Inhibitory : {0}".format(int(CI * N_neurons)))
-print("Excitatory rate   : %.2f Hz" % rate_ex)
-print("Inhibitory rate   : %.2f Hz" % rate_in)
-print("Building time     : %.2f s" % build_time)
-print("Simulation time   : %.2f s" % sim_time)
+print(f"Number of neurons : {N_neurons}")
+print(f"Number of synapses: {num_synapses}")
+print(f"       Exitatory  : {int(CE * N_neurons) + N_neurons}")
+print(f"       Inhibitory : {int(CI * N_neurons)}")
+print(f"Excitatory rate   : {rate_ex:.2f} Hz")
+print(f"Inhibitory rate   : {rate_in:.2f} Hz")
+print(f"Building time     : {build_time:.2f} s")
+print(f"Simulation time   : {sim_time:.2f} s")
 
 ###############################################################################
 # Plot a raster of the excitatory neurons and a histogram.

--- a/pynest/examples/brunel_siegert_nest.py
+++ b/pynest/examples/brunel_siegert_nest.py
@@ -193,5 +193,5 @@ data = multimeter.events
 rates_ex = data['rate'][numpy.where(data['senders'] == siegert_ex.global_id)]
 rates_in = data['rate'][numpy.where(data['senders'] == siegert_in.global_id)]
 times = data['times'][numpy.where(data['senders'] == siegert_in.global_id)]
-print("Excitatory rate   : %.2f Hz" % rates_ex[-1])
-print("Inhibitory rate   : %.2f Hz" % rates_in[-1])
+print(f"Excitatory rate   : {rates_ex[-1]:.2f} Hz")
+print(f"Inhibitory rate   : {rates_in[-1]:.2f} Hz")

--- a/pynest/examples/clopath_synapse_small_network.py
+++ b/pynest/examples/clopath_synapse_small_network.py
@@ -166,8 +166,8 @@ exc_conns_senders = np.array(exc_conns.source)
 exc_conns_targets = np.array(exc_conns.target)
 exc_conns_weights = np.array(exc_conns.weight)
 idx_array = np.argsort(exc_conns_senders)
-targets = np.reshape(exc_conns_targets[idx_array], (10, 10-1))
-weights = np.reshape(exc_conns_weights[idx_array], (10, 10-1))
+targets = np.reshape(exc_conns_targets[idx_array], (10, 10 - 1))
+weights = np.reshape(exc_conns_weights[idx_array], (10, 10 - 1))
 
 # Sort according to target
 for i, (trgs, ws) in enumerate(zip(targets, weights)):

--- a/pynest/examples/correlospinmatrix_detector_two_neuron.py
+++ b/pynest/examples/correlospinmatrix_detector_two_neuron.py
@@ -29,7 +29,7 @@ of the individual neurons and between them, repsectively.
 References
 ~~~~~~~~~~~~
 
-.. [1] Ginzburg and Sompolinsky (1994). Theory of correlations in stochastic neural netoworks. 50(4) p. 3175. Fig. 1.
+.. [1] Ginzburg and Sompolinsky (1994). Theory of correlations in stochastic neural networks. 50(4) p. 3175. Fig. 1.
 
 
 """

--- a/pynest/examples/gap_junctions_inhibitory_network.py
+++ b/pynest/examples/gap_junctions_inhibitory_network.py
@@ -151,7 +151,7 @@ hz_rate = (1000.0 * n_spikes / simtime) / n_neuron
 
 plt.figure(1)
 plt.plot(times, spikes, 'o')
-plt.title('Average spike rate (Hz): %.2f' % hz_rate)
+plt.title(f'Average spike rate (Hz): {hz_rate:.2f}')
 plt.xlabel('time (ms)')
 plt.ylabel('neuron no')
 plt.show()

--- a/pynest/examples/gif_cond_exp_multisynapse.py
+++ b/pynest/examples/gif_cond_exp_multisynapse.py
@@ -26,6 +26,9 @@ gif_cond_exp_multisynapse
 
 """
 
+import nest
+import numpy as np
+
 neuron = nest.Create('gif_cond_exp_multisynapse',
                      params={'E_rev': [0.0, -85.0],
                              'tau_syn': [4.0, 8.0]})
@@ -36,7 +39,7 @@ spike = nest.Create('spike_generator', params={'spike_times':
 delays = [1., 30.]
 w = [1., 5.]
 for syn in range(2):
-    nest.Connect(spike, neuron, syn_spec={'model': 'static_synapse',
+    nest.Connect(spike, neuron, syn_spec={'synapse_model': 'static_synapse',
                                           'receptor_type': 1 + syn,
                                           'weight': w[syn],
                                           'delay': delays[syn]})

--- a/pynest/examples/gif_pop_psc_exp.py
+++ b/pynest/examples/gif_pop_psc_exp.py
@@ -121,7 +121,7 @@ nest.ResetKernel()
 nest.SetKernelStatus({'resolution': dt,
                       'print_time': True,
                       'local_num_threads': 1})
-t0 = nest.GetKernelStatus('time')
+t0 = nest.GetKernelStatus('biological_time')
 
 nest_pops = nest.Create('gif_pop_psc_exp', M)
 
@@ -246,7 +246,7 @@ plt.xlabel('time [ms]')
 nest.ResetKernel()
 nest.SetKernelStatus(
     {'resolution': dt, 'print_time': True, 'local_num_threads': 1})
-t0 = nest.GetKernelStatus('time')
+t0 = nest.GetKernelStatus('biological_time')
 
 nest_pops = []
 for k in range(M):

--- a/pynest/examples/hh_psc_alpha.py
+++ b/pynest/examples/hh_psc_alpha.py
@@ -26,7 +26,7 @@ This example produces a rate-response (FI) curve of the Hodgkin-Huxley
 neuron ``hh_psc_alpha`` in response to a range of different current (DC) stimulations.
 The result is plotted using matplotlib.
 
-Since a DC input affetcs only the neuron's channel dynamics, this routine
+Since a DC input affects only the neuron's channel dynamics, this routine
 does not yet check correctness of synaptic response.
 """
 

--- a/pynest/examples/hh_psc_alpha.py
+++ b/pynest/examples/hh_psc_alpha.py
@@ -59,7 +59,7 @@ amplitudes = np.zeros(n_data)
 event_freqs = np.zeros(n_data)
 for i, amp in enumerate(range(dcfrom, dcto, dcstep)):
     neuron.I_e = float(amp)
-    print("Simulating with current I={} pA".format(amp))
+    print(f"Simulating with current I={amp} pA")
     nest.Simulate(1000)  # one second warm-up time for equilibrium state
     sr.n_events = 0  # then reset spike counts
     nest.Simulate(simtime)  # another simulation call to record firing rate

--- a/pynest/examples/if_curve.py
+++ b/pynest/examples/if_curve.py
@@ -26,7 +26,7 @@ This example illustrates how to measure the I-F curve of a neuron.
 The program creates a small group of neurons and injects a noisy current
 :math:`I(t) = I_mean + I_std*W(t)`
 where :math:`W(t)` is a white noise process.
-The programm systematically drives the current through a series of  values in
+The program systematically drives the current through a series of  values in
 the two-dimensional `(I_mean, I_std)` space and measures the firing rate of
 the neurons.
 

--- a/pynest/examples/intrinsic_currents_spiking.py
+++ b/pynest/examples/intrinsic_currents_spiking.py
@@ -119,7 +119,7 @@ for index, (rec_name, rec_wgt) in enumerate(w_recep.items()):
     nest.Connect(p_gens[index], nrn, syn_spec={'receptor_type': receptors[rec_name], 'weight': rec_wgt})
 
 ###############################################################################
-# We then connnect the ``multimeter``. Note that the multimeter is connected to
+# We then connect the ``multimeter``. Note that the multimeter is connected to
 # the neuron, not the other way around.
 
 nest.Connect(mm, nrn)

--- a/pynest/examples/lin_rate_ipn_network.py
+++ b/pynest/examples/lin_rate_ipn_network.py
@@ -44,9 +44,9 @@ T = 100.0  # Simulation time in ms
 # Definition of the number of neurons
 
 order = 50
-NE = int(4 * order)  # number of excitatory neurons
-NI = int(1 * order)  # number of inhibitory neurons
-N = int(NE+NI)       # total number of neurons
+NE = int(4 * order)    # number of excitatory neurons
+NI = int(1 * order)    # number of inhibitory neurons
+N = int(NE + NI)       # total number of neurons
 
 ###############################################################################
 # Definition of the connections
@@ -127,7 +127,7 @@ nest.Connect(n_i, n_e, conn_e, syn_i)
 ###############################################################################
 # Connect recording device to rate units
 
-nest.Connect(mm, n_e+n_i)
+nest.Connect(mm, n_e + n_i)
 
 ###############################################################################
 # Simulate the network

--- a/pynest/examples/mc_neuron.py
+++ b/pynest/examples/mc_neuron.py
@@ -54,10 +54,10 @@ nest.ResetKernel()
 
 
 syns = nest.GetDefaults('iaf_cond_alpha_mc')['receptor_types']
-print("iaf_cond_alpha_mc receptor_types: {0}".format(syns))
+print(f"iaf_cond_alpha_mc receptor_types: {syns}")
 
 rqs = nest.GetDefaults('iaf_cond_alpha_mc')['recordables']
-print("iaf_cond_alpha_mc recordables   : {0}".format(rqs))
+print(f"iaf_cond_alpha_mc recordables   : {rqs}")
 
 ###############################################################################
 # The simulation parameters are assigned to variables.

--- a/pynest/examples/multimeter_file.py
+++ b/pynest/examples/multimeter_file.py
@@ -72,7 +72,7 @@ print("iaf_cond_alpha recordables: {0}".format(
 #    (`V_reset`, in mV) are specified.
 #  * For the ``multimeter``, the time interval for recording (`interval`, in
 #    ms) and the measures to record (membrane potential `V_m` in mV and
-#    excitatory and inhibitoy synaptic conductances `g_ex` and`g_in` in nS)
+#    excitatory and inhibitory synaptic conductances `g_ex` and`g_in` in nS)
 #    are set.
 #
 #  In addition, more parameters can be modified for writing to file:

--- a/pynest/examples/music_cont_out_proxy_example/nest_script.py
+++ b/pynest/examples/music_cont_out_proxy_example/nest_script.py
@@ -33,8 +33,6 @@ and cannot be enabled at the same time.
 
 """
 import nest
-import music
-import numpy
 
 proxy = nest.Create('music_cont_out_proxy', 1)
 proxy.port_name = 'out'

--- a/pynest/examples/music_cont_out_proxy_example/receiver_script.py
+++ b/pynest/examples/music_cont_out_proxy_example/receiver_script.py
@@ -52,6 +52,4 @@ start = dropwhile(lambda t: t < mintime, runtime)
 times = takewhile(lambda t: t < maxtime, start)
 for time in times:
     val = data
-    sys.stdout.write(
-        "t={}\treceiver {}: received {}\n".
-        format(time, rank, val))
+    sys.stdout.write(f"t={time}\treceiver {rank}: received {val}\n")

--- a/pynest/examples/pulsepacket.py
+++ b/pynest/examples/pulsepacket.py
@@ -104,8 +104,8 @@ def make_psp(Time, Tau_s, Tau_m, Cm, Weight):
     term1 = (1 / Tau_s - 1 / Tau_m)
     term2 = numpy.exp(-Time / Tau_s)
     term3 = numpy.exp(-Time / Tau_m)
-    PSP = (Weight / Cm * numpy.exp(1) / Tau_s
-           * (((-Time * term2) / term1) + (term3 - term2) / term1 ** 2))
+    PSP = (Weight / Cm * numpy.exp(1) / Tau_s *
+           (((-Time * term2) / term1) + (term3 - term2) / term1 ** 2))
     return PSP * 1e3
 
 
@@ -181,8 +181,8 @@ psp_norm = psp / psp_amp
 psp_norm = numpy.pad(psp_norm, [len(psp_norm) - 1, 1], mode='constant')
 U = a * psp_amp * numpy.convolve(gauss, psp_norm)
 ulen = len(U)
-t_U = (convolution_resolution * numpy.linspace(-ulen / 2., ulen / 2., ulen)
-       + pulsetime + 1.)
+t_U = (convolution_resolution * numpy.linspace(-ulen / 2., ulen / 2., ulen) +
+       pulsetime + 1.)
 
 
 ###############################################################################

--- a/pynest/examples/pulsepacket.py
+++ b/pynest/examples/pulsepacket.py
@@ -104,8 +104,8 @@ def make_psp(Time, Tau_s, Tau_m, Cm, Weight):
     term1 = (1 / Tau_s - 1 / Tau_m)
     term2 = numpy.exp(-Time / Tau_s)
     term3 = numpy.exp(-Time / Tau_m)
-    PSP = (Weight / Cm * numpy.exp(1) / Tau_s *
-           (((-Time * term2) / term1) + (term3 - term2) / term1 ** 2))
+    PSP = (Weight / Cm * numpy.exp(1) / Tau_s
+           * (((-Time * term2) / term1) + (term3 - term2) / term1 ** 2))
     return PSP * 1e3
 
 
@@ -141,7 +141,7 @@ sig = Sdev
 mu = 0.0
 x = numpy.arange(-4 * sig, 4 * sig, Convolution_resolution)
 term1 = 1 / (sig * numpy.sqrt(2 * numpy.pi))
-term2 = numpy.exp(-(x - mu) ** 2 / (sig ** 2 * 2))
+term2 = numpy.exp(-(x - mu)**2 / (sig**2 * 2))
 gauss = term1 * term2 * Convolution_resolution
 
 
@@ -181,8 +181,8 @@ psp_norm = psp / psp_amp
 psp_norm = numpy.pad(psp_norm, [len(psp_norm) - 1, 1], mode='constant')
 U = a * psp_amp * numpy.convolve(gauss, psp_norm)
 ulen = len(U)
-t_U = (convolution_resolution * numpy.linspace(-ulen / 2., ulen / 2., ulen) +
-       pulsetime + 1.)
+t_U = (convolution_resolution * numpy.linspace(-ulen / 2., ulen / 2., ulen)
+       + pulsetime + 1.)
 
 
 ###############################################################################

--- a/pynest/examples/rate_neuron_dm.py
+++ b/pynest/examples/rate_neuron_dm.py
@@ -95,7 +95,7 @@ fig = plt.figure(facecolor=face, edgecolor=edge, figsize=fig_size)
 dt = 1e-3
 sigma = [0.0, 0.1, 0.2]
 dE = [0.0, 0.004, 0.008]
-T = numpy.linspace(0, 200, 200 / dt - 1)
+T = numpy.linspace(0, 200, int(200/dt) - 1)
 for i in range(9):
     c = i % 3
     r = int(i / 3)

--- a/pynest/examples/repeated_stimulation.py
+++ b/pynest/examples/repeated_stimulation.py
@@ -41,7 +41,7 @@ relative to the ``origin``.
 
 
 ###############################################################################
-# First, the modules needed for simulation and analyis are imported.
+# First, the modules needed for simulation and analysis are imported.
 
 
 import nest

--- a/pynest/examples/repeated_stimulation.py
+++ b/pynest/examples/repeated_stimulation.py
@@ -105,7 +105,7 @@ nest.Connect(pg, sr)
 
 
 for n in range(num_trials):
-    pg.origin = nest.GetKernelStatus('time')
+    pg.origin = nest.GetKernelStatus('biological_time')
     nest.Simulate(trial_duration)
 
 

--- a/pynest/examples/sensitivity_to_perturbation.py
+++ b/pynest/examples/sensitivity_to_perturbation.py
@@ -183,7 +183,7 @@ for trial in [0, 1]:
     # the simulation Kernel. In addition, we ensure that there is no spike left in
     # the spike recorder.
 
-    nest.SetKernelStatus({"rng_seeds": [seed_NEST], 'time': 0.0})
+    nest.SetKernelStatus({"rng_seeds": [seed_NEST], 'biological_time': 0.0})
     spikerecorder.n_events = 0
 
     # We assign random initial membrane potentials to all neurons

--- a/pynest/examples/sensitivity_to_perturbation.py
+++ b/pynest/examples/sensitivity_to_perturbation.py
@@ -24,7 +24,7 @@ Sensitivity to perturbation
 ---------------------------
 
 This script simulates a network in two successive trials, which are identical
-except for one extra input spike in the second realisation (a small
+except for one extra input spike in the second realization (a small
 perturbation). The network consists of recurrent, randomly connected excitatory
 and inhibitory neurons. Its activity is driven by an external Poisson input
 provided to all neurons independently. In order to ensure that the network is
@@ -34,7 +34,7 @@ reset appropriately between the trials, we do the following steps:
 - resetting the random network generator
 - resetting the internal clock
 - deleting all entries in the spike recorder
-- introducing a hyperpolarisation phase between the trials
+- introducing a hyperpolarization phase between the trials
   (in order to avoid that spikes remaining in the NEST memory
   after the first simulation are fed into the second simulation)
 
@@ -113,7 +113,7 @@ T = 1000.                 # simulation time per trial (ms)
 fade_out = 2. * delay     # fade out time (ms)
 dt = 0.01                 # simulation time resolution (ms)
 seed_NEST = 30            # seed of random number generator in Nest
-seed_numpy = 30           # seed of random number generator in numpy
+seed_numpy = 30           # seed of random number generator in NumPy
 
 senders = []
 spiketimes = []
@@ -153,10 +153,10 @@ for trial in [0, 1]:
     # Afterwards we create a ``poisson_generator`` that provides spikes (the external
     # input) to the neurons until time ``T`` is reached.
     # Afterwards a ``dc_generator``, which is also connected to the whole population,
-    # provides a stong hyperpolarisation step for a short time period ``fade_out``.
+    # provides a strong hyperpolarization step for a short time period ``fade_out``.
     #
     # The ``fade_out`` period has to last at least twice as long as the simulation
-    # resolution to supress the neurons from firing.
+    # resolution to suppress the neurons from firing.
 
     ext = nest.Create("poisson_generator",
                       params={'rate': rate_ext, 'stop': T})

--- a/pynest/examples/sinusoidal_gamma_generator.py
+++ b/pynest/examples/sinusoidal_gamma_generator.py
@@ -271,13 +271,10 @@ spikes = step(t, n,
               seed=123, dt=dt)
 plot_hist(spikes)
 exp = np.zeros(int(steps))
-exp[:int(steps / 2)] = (40. +
-                        40. * np.sin(np.arange(0, t / 1000. * np.pi * 10,
-                                               t / 1000. * np.pi * 10. /
-                                               (steps / 2))))
-exp[int(steps / 2):] = (40. + 20. * np.sin(np.arange(0, t / 1000. * np.pi * 10,
-                                                     t / 1000. * np.pi * 10. /
-                                                     (steps / 2)) + offset))
+exp[:int(steps / 2)] = (40. + 40. * np.sin(np.arange(
+    0, t / 1000. * np.pi * 10, t / 1000. * np.pi * 10. / (steps / 2))))
+exp[int(steps / 2):] = (40. + 20. * np.sin(np.arange(
+    0, t / 1000. * np.pi * 10, t / 1000. * np.pi * 10. / (steps / 2)) + offset))
 plt.plot(exp, 'r')
 plt.title('Rate Modulation: 40 -> 20')
 
@@ -297,12 +294,10 @@ spikes = step(t, n,
               seed=123, dt=dt)
 plot_hist(spikes)
 exp = np.zeros(int(steps))
-exp[:int(steps / 2)] = (20. + 20. * np.sin(np.arange(0, t / 1000. * np.pi * 10,
-                                                     t / 1000. * np.pi * 10. /
-                                                     (steps / 2))))
-exp[int(steps / 2):] = (50. + 50. * np.sin(np.arange(0, t / 1000. * np.pi * 10,
-                                                     t / 1000. * np.pi * 10. /
-                                                     (steps / 2)) + offset))
+exp[:int(steps / 2)] = (20. + 20. * np.sin(np.arange(
+    0, t / 1000. * np.pi * 10, t / 1000. * np.pi * 10. / (steps / 2))))
+exp[int(steps / 2):] = (50. + 50. * np.sin(np.arange(
+    0, t / 1000. * np.pi * 10, t / 1000. * np.pi * 10. / (steps / 2)) + offset))
 plt.plot(exp, 'r')
 plt.title('DC Rate and Rate Modulation: 20 -> 50')
 plt.ylabel('Spikes per second')
@@ -323,9 +318,8 @@ spikes = step(t, n,
 plot_hist(spikes)
 exp = np.zeros(int(steps))
 exp[:int(steps / 2)] = 40. * np.ones(int(steps / 2))
-exp[int(steps / 2):] = (40. + 40. * np.sin(np.arange(0, t / 1000. * np.pi * 20,
-                                                     t / 1000. * np.pi * 20. /
-                                                     (steps / 2))))
+exp[int(steps / 2):] = (40. + 40. * np.sin(np.arange(
+    0, t / 1000. * np.pi * 20, t / 1000. * np.pi * 20. / (steps / 2))))
 plt.plot(exp, 'r')
 plt.title('Rate Modulation: 0 -> 40')
 plt.xlabel('Time [ms]')
@@ -347,13 +341,10 @@ spikes = step(t, n,
 plot_hist(spikes)
 exp = np.zeros(int(steps))
 
-exp[:int(steps / 2)] = (60. + 60. * np.sin(np.arange(0, t / 1000. * np.pi * 10,
-                                                     t / 1000. * np.pi * 10. /
-                                                     (steps / 2))))
-exp[int(steps / 2):] = (60. + 60. * np.sin(np.arange(0, t / 1000. * np.pi * 10,
-                                                     t / 1000. * np.pi * 10. /
-                                                     (steps / 2)) +
-                                           offset + np.pi))
+exp[:int(steps / 2)] = (60. + 60. * np.sin(np.arange(
+    0, t / 1000. * np.pi * 10, t / 1000. * np.pi * 10. / (steps / 2))))
+exp[int(steps / 2):] = (60. + 60. * np.sin(np.arange(
+    0, t / 1000. * np.pi * 10, t / 1000. * np.pi * 10. / (steps / 2)) + offset + np.pi))
 plt.plot(exp, 'r')
 plt.title('Modulation Phase: 0 -> Pi')
 plt.xlabel('Time [ms]')

--- a/pynest/examples/sinusoidal_gamma_generator.py
+++ b/pynest/examples/sinusoidal_gamma_generator.py
@@ -162,7 +162,7 @@ nest.Connect(g, p)
 nest.Connect(p, s)
 
 nest.Simulate(200)
-ev = s[0].events
+ev = s.events
 plt.subplot(224)
 plt.plot(ev['times'], ev['senders'] - min(ev['senders']), 'o')
 plt.ylim([-0.5, 19.5])

--- a/pynest/examples/spatial/grid_iaf_oc.py
+++ b/pynest/examples/spatial/grid_iaf_oc.py
@@ -47,8 +47,8 @@ for ctr in [(0.0, 0.0), (-2.0, 2.0), (0.5, 1.0)]:
     plt.axes().set_xticks(np.arange(-3.0, 3.1, 1.0))
     plt.axes().set_yticks(np.arange(-3.0, 3.1, 1.0))
     plt.grid(True)
-    plt.xlabel('4 Columns, Extent: 1.5, Center: %.1f' % ctr[0])
-    plt.ylabel('2 Rows, Extent: 1.0, Center: %.1f' % ctr[1])
+    plt.xlabel(f'4 Columns, Extent: 1.5, Center: {ctr[0]:.1f}')
+    plt.ylabel(f'2 Rows, Extent: 1.0, Center: {ctr[1]:.1f}')
 
     plt.show()
     # plt.savefig('grid_iaf_oc_{}_{}.png'.format(ctr[0], ctr[1]))

--- a/pynest/examples/spatial/hill_tononi_Vp.py
+++ b/pynest/examples/spatial/hill_tononi_Vp.py
@@ -81,7 +81,7 @@ Philosophy_
    tutorial
 
 Preparations_
-   Neccessary steps to use NEST
+   Necessary steps to use NEST
 
 `Configurable Parameters`_
    Define adjustable network parameters

--- a/pynest/examples/spatial/hill_tononi_Vp.py
+++ b/pynest/examples/spatial/hill_tononi_Vp.py
@@ -429,8 +429,8 @@ Vp_h_layers = {}
 Vp_v_layers = {}
 for layer_name, num_layers in name_dict.items():
     for i in range(num_layers):
-        Vp_h_layers['{}_{}'.format(layer_name, i)] = nest.Create(layer_name, positions=layerGrid)
-        Vp_v_layers['{}_{}'.format(layer_name, i)] = nest.Create(layer_name, positions=layerGrid)
+        Vp_h_layers[f'{layer_name}_{i}'] = nest.Create(layer_name, positions=layerGrid)
+        Vp_v_layers[f'{layer_name}_{i}'] = nest.Create(layer_name, positions=layerGrid)
 
 
 ##############################################################################
@@ -653,8 +653,8 @@ print("Connecting: cortico-cortical, same orientation")
 for source, target, conn_spec, syn_spec in ccConnections:
     for src_i in range(name_dict[source]):
         for tgt_i in range(name_dict[target]):
-            source_name = '{}_{}'.format(source, src_i)
-            target_name = '{}_{}'.format(target, tgt_i)
+            source_name = f'{source}_{src_i}'
+            target_name = f'{target}_{tgt_i}'
             nest.Connect(Vp_h_layers[source_name], Vp_h_layers[target_name], conn_spec, syn_spec)
             nest.Connect(Vp_v_layers[source_name], Vp_v_layers[target_name], conn_spec, syn_spec)
 
@@ -663,8 +663,8 @@ print("Connecting: cortico-cortical, other orientation")
 for source, target, conn_spec, syn_spec in ccxConnections:
     for src_i in range(name_dict[source]):
         for tgt_i in range(name_dict[target]):
-            source_name = '{}_{}'.format(source, src_i)
-            target_name = '{}_{}'.format(target, tgt_i)
+            source_name = f'{source}_{src_i}'
+            target_name = f'{target}_{tgt_i}'
             nest.Connect(Vp_h_layers[source_name], Vp_v_layers[target_name], conn_spec, syn_spec)
             nest.Connect(Vp_v_layers[source_name], Vp_h_layers[target_name], conn_spec, syn_spec)
 
@@ -672,14 +672,14 @@ for source, target, conn_spec, syn_spec in ccxConnections:
 print("Connecting: cortico-thalamic")
 for source, conn_spec, syn_spec in ctConnections:
     for src_i in range(name_dict[source]):
-        source_name = '{}_{}'.format(source, src_i)
+        source_name = f'{source}_{src_i}'
         nest.Connect(Vp_h_layers[source_name], TpRelay, conn_spec, syn_spec)
         nest.Connect(Vp_h_layers[source_name], TpInter, conn_spec, syn_spec)
         nest.Connect(Vp_v_layers[source_name], TpRelay, conn_spec, syn_spec)
         nest.Connect(Vp_v_layers[source_name], TpInter, conn_spec, syn_spec)
 
 for src_i in range(name_dict['L56pyr']):
-    source_name = 'L56pyr_{}'.format(src_i)
+    source_name = f'L56pyr_{src_i}'
     nest.Connect(Vp_h_layers[source_name], Rp, corRet, corRet_syn_spec)
     nest.Connect(Vp_v_layers[source_name], Rp, corRet, corRet_syn_spec)
 
@@ -713,7 +713,7 @@ for conn in [{"targets": "L4pyr", "conn_spec": {"p": 0.5}},
     conn_spec = thalCorRect_conn_spec.copy()
     conn_spec.update(conn['conn_spec'])
     for trg_i in range(name_dict[conn['targets']]):
-        target_name = '{}_{}'.format(conn['targets'], trg_i)
+        target_name = f'{conn["targets"]}_{trg_i}'
         nest.Connect(
             TpRelay, Vp_h_layers[target_name], conn_spec, thalCorRect_syn_spec)
 
@@ -727,7 +727,7 @@ for conn in [{"targets": "L4pyr", "conn_spec": {"p": 0.5}},
     conn_spec = thalCorRect_conn_spec.copy()
     conn_spec.update(conn['conn_spec'])
     for trg_i in range(name_dict[conn['targets']]):
-        target_name = '{}_{}'.format(conn['targets'], trg_i)
+        target_name = f'{conn["targets"]}_{trg_i}'
         nest.Connect(
             TpRelay, Vp_v_layers[target_name], conn_spec, thalCorRect_syn_spec)
 
@@ -744,7 +744,7 @@ thalCorDiff_syn_spec = {"synapse_model": "AMPA",
 for conn in [{"targets": "L4pyr"},
              {"targets": "L56pyr"}]:
     for trg_i in range(name_dict[conn['targets']]):
-        target_name = '{}_{}'.format(conn['targets'], trg_i)
+        target_name = f'{conn["targets"]}_{trg_i}'
         nest.Connect(TpRelay, Vp_h_layers[target_name], thalCorDiff_conn_spec, thalCorDiff_syn_spec)
         nest.Connect(TpRelay, Vp_v_layers[target_name], thalCorDiff_conn_spec, thalCorDiff_syn_spec)
 
@@ -936,7 +936,7 @@ for t in np.arange(0, Params['simtime'], Params['sim_interval']):
 
         # update image data and title
         im.set_data(np.reshape(d, (Params['N'], Params['N'])))
-        ax.set_title(name + ', t = %6.1f ms' % nest.GetKernelStatus()['time'])
+        ax.set_title(name + f', t = {nest.GetKernelStatus("biological_time"):6.1f} ms')
 
     # We need to pause because drawing of the figure happens while the main code is sleeping
     plt.pause(0.0001)

--- a/pynest/examples/synapsecollection.py
+++ b/pynest/examples/synapsecollection.py
@@ -35,7 +35,7 @@ def makeMatrix(sources, targets, weights):
     """
     Returns a matrix with the weights between the source and target node_ids.
     """
-    aa = np.zeros((max(sources)+1, max(targets)+1))
+    aa = np.zeros((max(sources) + 1, max(targets) + 1))
 
     for src, trg, wght in zip(sources, targets, weights):
         aa[src, trg] += wght
@@ -49,9 +49,9 @@ def plotMatrix(srcs, tgts, weights, title, pos):
     """
     plt.subplot(pos)
     plt.matshow(makeMatrix(srcs, tgts, weights), fignum=False)
-    plt.xlim([min(tgts)-0.5, max(tgts)+0.5])
+    plt.xlim([min(tgts) - 0.5, max(tgts) + 0.5])
     plt.xlabel('target')
-    plt.ylim([max(srcs)+0.5, min(srcs)-0.5])
+    plt.ylim([max(srcs) + 0.5, min(srcs) - 0.5])
     plt.ylabel('source')
     plt.title(title)
     plt.colorbar(fraction=0.046, pad=0.04)
@@ -83,7 +83,7 @@ plotMatrix(srcs, tgts, weights, 'Uniform weight', 121)
 Add some weights to the connections, and plot the updated weight matrix.
 """
 # We can set data of the connections with a simple set() call.
-w = [{'weight': x*1.0} for x in range(1, 11)]
+w = [{'weight': x * 1.0} for x in range(1, 11)]
 conns.set(w)
 weights = conns.weight
 
@@ -165,7 +165,7 @@ plotMatrix(srcs, tgts, weights, 'Connections with stdp_synapse', 223)
 # Get SynapseCollection consisting of the fixed_total_number connections, but set
 # weight before plotting
 conns = nest.GetConnections(nrns[5:10], nrns[:5])
-w = [{'weight': x*1.0} for x in range(1, 6)]
+w = [{'weight': x * 1.0} for x in range(1, 6)]
 conns.set(w)
 g = conns.get(['source', 'target', 'weight'])
 srcs = g['source']

--- a/pynest/examples/testiaf.py
+++ b/pynest/examples/testiaf.py
@@ -78,7 +78,7 @@ def build_network(dt):
 # voltage trace is plotted
 
 for dt in [0.1, 0.5, 1.0]:
-    print("Running simulation with dt=%.2f" % dt)
+    print(f"Running simulation with dt={dt:.2f}")
     vm, sr = build_network(dt)
 
     nest.Simulate(1000.0)
@@ -100,8 +100,8 @@ for dt in [0.1, 0.5, 1.0]:
 ###########################################################################
 # Using the matplotlib library the voltage trace is plotted over time
 
-    plt.plot(times, potentials, label="dt=%.2f" % dt)
-    print("  Number of spikes: {0}".format(sr.n_events))
+    plt.plot(times, potentials, label=f"dt={dt:.2f}")
+    print(f"  Number of spikes: {sr.n_events}")
 
 ###########################################################################
 # Finally the axis are labelled and a legend is generated

--- a/pynest/examples/urbanczik_synapse_example.py
+++ b/pynest/examples/urbanczik_synapse_example.py
@@ -93,7 +93,6 @@ def h(U, nrn_params):
     '''
     derivative of the rate function phi
     '''
-    phi_max = nrn_params['phi_max']
     k = nrn_params['rate_slope']
     beta = nrn_params['beta']
     theta = nrn_params['theta']

--- a/pynest/examples/urbanczik_synapse_example.py
+++ b/pynest/examples/urbanczik_synapse_example.py
@@ -237,10 +237,7 @@ sr = nest.Create('spike_recorder', n_pg)
 nest.Connect(prrt_nrns_pg, sr, {'rule': 'one_to_one'})
 
 nest.Simulate(pattern_duration)
-t_srs = []
-for i, ssr in enumerate(nest.GetStatus(sr)):
-    t_sr = ssr['events']['times']
-    t_srs.append(t_sr)
+t_srs = [ssr.get('events', 'times') for ssr in sr]
 
 nest.ResetKernel()
 nest.SetKernelStatus({'resolution': resolution})
@@ -306,27 +303,26 @@ for i in np.arange(n_rep_total):
 read out devices
 '''
 # multimeter
-rec = nest.GetStatus(mm)[0]['events']
-t = rec['times']
-V_s = rec['V_m.s']
-V_d = rec['V_m.p']
+mm_events = mm.events
+t = mm_events['times']
+V_s = mm_events['V_m.s']
+V_d = mm_events['V_m.p']
 V_d_star = V_w_star(V_d, nrn_params)
-g_in = rec['g_in.s']
-g_ex = rec['g_ex.s']
-I_ex = rec['I_ex.p']
-I_in = rec['I_in.p']
+g_in = mm_events['g_in.s']
+g_ex = mm_events['g_ex.s']
+I_ex = mm_events['I_ex.p']
+I_in = mm_events['I_in.p']
 U_M = matching_potential(g_ex, g_in, nrn_params)
 
 # weight recorder
-data = nest.GetStatus(wr)
-senders = data[0]['events']['senders']
-targets = data[0]['events']['targets']
-weights = data[0]['events']['weights']
-times = data[0]['events']['times']
+wr_events = wr.events
+senders = wr_events['senders']
+targets = wr_events['targets']
+weights = wr_events['weights']
+times = wr_events['times']
 
 # spike recorder
-data = nest.GetStatus(sr_soma)[0]['events']
-spike_times_soma = data['times']
+spike_times_soma = sr_soma.get('events', 'times')
 
 '''
 plot results

--- a/pynest/examples/vinit_example.py
+++ b/pynest/examples/vinit_example.py
@@ -60,8 +60,7 @@ import matplotlib.pyplot as plt
 # Then, a simulation with a duration of 75 ms is started with ``Simulate``.
 #
 # When the simulation has finished, the recorded times and membrane voltages
-# are read from the voltmeter via ``GetStatus`` where they can be accessed
-# through the key ``events`` of the status dictionary.
+# are read from the voltmeter via ``get``.
 #
 # Finally, the time course of the membrane voltages is plotted for each of
 # the different inital values.

--- a/pynest/examples/vinit_example.py
+++ b/pynest/examples/vinit_example.py
@@ -63,7 +63,7 @@ import matplotlib.pyplot as plt
 # are read from the voltmeter via ``get``.
 #
 # Finally, the time course of the membrane voltages is plotted for each of
-# the different inital values.
+# the different initial values.
 
 for vinit in numpy.arange(-100, -50, 10, float):
 


### PR DESCRIPTION
I've gone through all the PyNEST examples again to update them for NEST 3.0 so we can cross off a few more points in #1504. With this PR the following points can be crossed off:
- "Remove `SetDefaults()`"
- "Remove `nest.GetStatus`"
- "Incorporate NEST 3 features in examples"

And I think we also can cross off "Use pythonic approach", unless you have anything specific in mind for it. I'm not sure what is meant by the "Simplify parameter access" point, though.

I also fixed typos and updated some formatting to (hopefully) improve readability.